### PR TITLE
New SearchResult properties; Overrideable feedback ids

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 1.0.0-beta.26-SNAPSHOT
 
+### New features
+- [CORE] New properties are available `SearchSuggestion.matchingName`, `SearchSuggestion.serverIndex`, `SearchResult.matchingName`, `SearchResult.serverIndex`, `ResponseInfo.responseUuid`.
+- [CORE] Now customers can provide their own feedback IDs in `FeedbackEvent.feedbackId` and `MissingResultFeedbackEvent.feedbackId`.
+
 ### Mapbox dependencies
 - Search Native SDK `0.47.0`
 - Common SDK `21.1.0-rc.1`

--- a/MapboxSearch/sdk/api/api-metalava.txt
+++ b/MapboxSearch/sdk/api/api-metalava.txt
@@ -619,7 +619,9 @@ package com.mapbox.search {
 
   @kotlinx.parcelize.Parcelize public final class ResponseInfo implements android.os.Parcelable {
     method public com.mapbox.search.RequestOptions getRequestOptions();
+    method public String? getResponseUuid();
     property public final com.mapbox.search.RequestOptions requestOptions;
+    property public final String? responseUuid;
   }
 
   @kotlinx.parcelize.Parcelize public final class ReverseGeoOptions implements android.os.Parcelable {
@@ -927,14 +929,17 @@ package com.mapbox.search.analytics {
   }
 
   public final class FeedbackEvent {
+    ctor public FeedbackEvent(@com.mapbox.search.analytics.FeedbackEvent.FeedbackReason String reason, String? text = null, android.graphics.Bitmap? screenshot = null, String? sessionId = null, String? feedbackId = null);
     ctor public FeedbackEvent(@com.mapbox.search.analytics.FeedbackEvent.FeedbackReason String reason, String? text = null, android.graphics.Bitmap? screenshot = null, String? sessionId = null);
     ctor public FeedbackEvent(@com.mapbox.search.analytics.FeedbackEvent.FeedbackReason String reason, String? text = null, android.graphics.Bitmap? screenshot = null);
     ctor public FeedbackEvent(@com.mapbox.search.analytics.FeedbackEvent.FeedbackReason String reason, String? text = null);
     ctor public FeedbackEvent(@com.mapbox.search.analytics.FeedbackEvent.FeedbackReason String reason);
+    method public String? getFeedbackId();
     method public String getReason();
     method public android.graphics.Bitmap? getScreenshot();
     method public String? getSessionId();
     method public String? getText();
+    property public final String? feedbackId;
     property public final String reason;
     property public final android.graphics.Bitmap? screenshot;
     property public final String? sessionId;
@@ -949,14 +954,17 @@ package com.mapbox.search.analytics {
   }
 
   public final class MissingResultFeedbackEvent {
+    ctor public MissingResultFeedbackEvent(com.mapbox.search.ResponseInfo responseInfo, String? text = null, android.graphics.Bitmap? screenshot = null, String? sessionId = null, String? feedbackId = null);
     ctor public MissingResultFeedbackEvent(com.mapbox.search.ResponseInfo responseInfo, String? text = null, android.graphics.Bitmap? screenshot = null, String? sessionId = null);
     ctor public MissingResultFeedbackEvent(com.mapbox.search.ResponseInfo responseInfo, String? text = null, android.graphics.Bitmap? screenshot = null);
     ctor public MissingResultFeedbackEvent(com.mapbox.search.ResponseInfo responseInfo, String? text = null);
     ctor public MissingResultFeedbackEvent(com.mapbox.search.ResponseInfo responseInfo);
+    method public String? getFeedbackId();
     method public com.mapbox.search.ResponseInfo getResponseInfo();
     method public android.graphics.Bitmap? getScreenshot();
     method public String? getSessionId();
     method public String? getText();
+    property public final String? feedbackId;
     property public final com.mapbox.search.ResponseInfo responseInfo;
     property public final android.graphics.Bitmap? screenshot;
     property public final String? sessionId;
@@ -1325,10 +1333,12 @@ package com.mapbox.search.result {
     method public Double? getEtaMinutes();
     method public String getId();
     method public String? getMakiIcon();
+    method public String? getMatchingName();
     method public com.mapbox.search.SearchResultMetadata? getMetadata();
     method public String getName();
     method public com.mapbox.search.RequestOptions getRequestOptions();
     method public java.util.List<com.mapbox.search.result.RoutablePoint>? getRoutablePoints();
+    method public Integer? getServerIndex();
     method public java.util.List<com.mapbox.search.result.SearchResultType> getTypes();
     property public abstract com.mapbox.search.result.SearchAddress? address;
     property public abstract java.util.List<java.lang.String> categories;
@@ -1338,10 +1348,12 @@ package com.mapbox.search.result {
     property public abstract Double? etaMinutes;
     property public abstract String id;
     property public abstract String? makiIcon;
+    property public abstract String? matchingName;
     property public abstract com.mapbox.search.SearchResultMetadata? metadata;
     property public abstract String name;
     property public abstract com.mapbox.search.RequestOptions requestOptions;
     property public abstract java.util.List<com.mapbox.search.result.RoutablePoint>? routablePoints;
+    property public abstract Integer? serverIndex;
     property public abstract java.util.List<com.mapbox.search.result.SearchResultType> types;
   }
 
@@ -1371,8 +1383,10 @@ package com.mapbox.search.result {
     method public Double? getEtaMinutes();
     method public String getId();
     method public String? getMakiIcon();
+    method public String? getMatchingName();
     method public String getName();
     method public com.mapbox.search.RequestOptions getRequestOptions();
+    method public Integer? getServerIndex();
     method public com.mapbox.search.result.SearchSuggestionType getType();
     method public boolean isBatchResolveSupported();
     property public abstract com.mapbox.search.result.SearchAddress? address;
@@ -1382,8 +1396,10 @@ package com.mapbox.search.result {
     property public abstract String id;
     property public abstract boolean isBatchResolveSupported;
     property public abstract String? makiIcon;
+    property public abstract String? matchingName;
     property public abstract String name;
     property public abstract com.mapbox.search.RequestOptions requestOptions;
+    property public abstract Integer? serverIndex;
     property public abstract com.mapbox.search.result.SearchSuggestionType type;
   }
 

--- a/MapboxSearch/sdk/api/sdk.api
+++ b/MapboxSearch/sdk/api/sdk.api
@@ -668,6 +668,7 @@ public final class com/mapbox/search/ResponseInfo : android/os/Parcelable {
 	public fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getRequestOptions ()Lcom/mapbox/search/RequestOptions;
+	public final fun getResponseUuid ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 	public fun writeToParcel (Landroid/os/Parcel;I)V
@@ -1020,10 +1021,12 @@ public final class com/mapbox/search/analytics/FeedbackEvent {
 	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
 	public fun <init> (Ljava/lang/String;Ljava/lang/String;Landroid/graphics/Bitmap;)V
 	public fun <init> (Ljava/lang/String;Ljava/lang/String;Landroid/graphics/Bitmap;Ljava/lang/String;)V
-	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Landroid/graphics/Bitmap;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final synthetic fun copy (Ljava/lang/String;Ljava/lang/String;Landroid/graphics/Bitmap;Ljava/lang/String;)Lcom/mapbox/search/analytics/FeedbackEvent;
-	public static synthetic fun copy$default (Lcom/mapbox/search/analytics/FeedbackEvent;Ljava/lang/String;Ljava/lang/String;Landroid/graphics/Bitmap;Ljava/lang/String;ILjava/lang/Object;)Lcom/mapbox/search/analytics/FeedbackEvent;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Landroid/graphics/Bitmap;Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Landroid/graphics/Bitmap;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final synthetic fun copy (Ljava/lang/String;Ljava/lang/String;Landroid/graphics/Bitmap;Ljava/lang/String;Ljava/lang/String;)Lcom/mapbox/search/analytics/FeedbackEvent;
+	public static synthetic fun copy$default (Lcom/mapbox/search/analytics/FeedbackEvent;Ljava/lang/String;Ljava/lang/String;Landroid/graphics/Bitmap;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/mapbox/search/analytics/FeedbackEvent;
 	public fun equals (Ljava/lang/Object;)Z
+	public final fun getFeedbackId ()Ljava/lang/String;
 	public final fun getReason ()Ljava/lang/String;
 	public final fun getScreenshot ()Landroid/graphics/Bitmap;
 	public final fun getSessionId ()Ljava/lang/String;
@@ -1052,10 +1055,12 @@ public final class com/mapbox/search/analytics/MissingResultFeedbackEvent {
 	public fun <init> (Lcom/mapbox/search/ResponseInfo;Ljava/lang/String;)V
 	public fun <init> (Lcom/mapbox/search/ResponseInfo;Ljava/lang/String;Landroid/graphics/Bitmap;)V
 	public fun <init> (Lcom/mapbox/search/ResponseInfo;Ljava/lang/String;Landroid/graphics/Bitmap;Ljava/lang/String;)V
-	public synthetic fun <init> (Lcom/mapbox/search/ResponseInfo;Ljava/lang/String;Landroid/graphics/Bitmap;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final synthetic fun copy (Lcom/mapbox/search/ResponseInfo;Ljava/lang/String;Landroid/graphics/Bitmap;Ljava/lang/String;)Lcom/mapbox/search/analytics/MissingResultFeedbackEvent;
-	public static synthetic fun copy$default (Lcom/mapbox/search/analytics/MissingResultFeedbackEvent;Lcom/mapbox/search/ResponseInfo;Ljava/lang/String;Landroid/graphics/Bitmap;Ljava/lang/String;ILjava/lang/Object;)Lcom/mapbox/search/analytics/MissingResultFeedbackEvent;
+	public fun <init> (Lcom/mapbox/search/ResponseInfo;Ljava/lang/String;Landroid/graphics/Bitmap;Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Lcom/mapbox/search/ResponseInfo;Ljava/lang/String;Landroid/graphics/Bitmap;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final synthetic fun copy (Lcom/mapbox/search/ResponseInfo;Ljava/lang/String;Landroid/graphics/Bitmap;Ljava/lang/String;Ljava/lang/String;)Lcom/mapbox/search/analytics/MissingResultFeedbackEvent;
+	public static synthetic fun copy$default (Lcom/mapbox/search/analytics/MissingResultFeedbackEvent;Lcom/mapbox/search/ResponseInfo;Ljava/lang/String;Landroid/graphics/Bitmap;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/mapbox/search/analytics/MissingResultFeedbackEvent;
 	public fun equals (Ljava/lang/Object;)Z
+	public final fun getFeedbackId ()Ljava/lang/String;
 	public final fun getResponseInfo ()Lcom/mapbox/search/ResponseInfo;
 	public final fun getScreenshot ()Landroid/graphics/Bitmap;
 	public final fun getSessionId ()Ljava/lang/String;
@@ -1443,10 +1448,12 @@ public abstract interface class com/mapbox/search/result/SearchResult : android/
 	public abstract fun getEtaMinutes ()Ljava/lang/Double;
 	public abstract fun getId ()Ljava/lang/String;
 	public abstract fun getMakiIcon ()Ljava/lang/String;
+	public abstract fun getMatchingName ()Ljava/lang/String;
 	public abstract fun getMetadata ()Lcom/mapbox/search/SearchResultMetadata;
 	public abstract fun getName ()Ljava/lang/String;
 	public abstract fun getRequestOptions ()Lcom/mapbox/search/RequestOptions;
 	public abstract fun getRoutablePoints ()Ljava/util/List;
+	public abstract fun getServerIndex ()Ljava/lang/Integer;
 	public abstract fun getTypes ()Ljava/util/List;
 }
 
@@ -1472,8 +1479,10 @@ public abstract interface class com/mapbox/search/result/SearchSuggestion : andr
 	public abstract fun getEtaMinutes ()Ljava/lang/Double;
 	public abstract fun getId ()Ljava/lang/String;
 	public abstract fun getMakiIcon ()Ljava/lang/String;
+	public abstract fun getMatchingName ()Ljava/lang/String;
 	public abstract fun getName ()Ljava/lang/String;
 	public abstract fun getRequestOptions ()Lcom/mapbox/search/RequestOptions;
+	public abstract fun getServerIndex ()Ljava/lang/Integer;
 	public abstract fun getType ()Lcom/mapbox/search/result/SearchSuggestionType;
 	public abstract fun isBatchResolveSupported ()Z
 }

--- a/MapboxSearch/sdk/src/main/java/com/mapbox/search/MapboxSearchSdk.kt
+++ b/MapboxSearch/sdk/src/main/java/com/mapbox/search/MapboxSearchSdk.kt
@@ -211,7 +211,14 @@ public object MapboxSearchSdk {
         }
 
         val analyticsService = TelemetryService(
-            application, accessToken, userAgent, locationEngine, viewportProvider, uuidProvider, ::getCoreEngineByApiType, formattedTimeProvider
+            context = application,
+            accessToken = accessToken,
+            userAgent = userAgent,
+            locationEngine = locationEngine,
+            viewportProvider = viewportProvider,
+            uuidProvider = uuidProvider,
+            coreEngineProvider = ::getCoreEngineByApiType,
+            formattedTimeProvider = formattedTimeProvider,
         )
 
         httpErrorsCache = HttpErrorsCacheImpl()

--- a/MapboxSearch/sdk/src/main/java/com/mapbox/search/ResponseInfo.kt
+++ b/MapboxSearch/sdk/src/main/java/com/mapbox/search/ResponseInfo.kt
@@ -15,9 +15,10 @@ import kotlinx.parcelize.Parcelize
  * therefore we don't have [CoreSearchResponse].
  *
  * Also, [coreSearchResponse] will equal `null` in the following cases:
- * - User selects [com.mapbox.search.result.SearchSuggestionType.SearchResultSuggestion] search suggestion;
+ * - User selects [com.mapbox.search.result.SearchSuggestionType.SearchResultSuggestion] search suggestion that represents V5 search result;
  * - User selects [com.mapbox.search.result.SearchSuggestionType.IndexableRecordItem] search suggestion;
- * - Batch retrieve of several search suggestions;
+ * - Batch retrieve of several search suggestions that represent V5 search result
+ *      or when all the suggestions is not resolvable in batch request (SearchSuggestion.isBatchResolveSupported == false);
  *
  * @property isReproducible true, if [coreSearchResponse] is not associated with provided [requestOptions],
  * meaning that [RequestOptions] will not contain all parameters, with which [CoreSearchResponse] may be reproduced.
@@ -34,6 +35,12 @@ public class ResponseInfo internal constructor(
     @get:JvmSynthetic
     internal val isReproducible: Boolean,
 ) : Parcelable {
+
+    /**
+     * Service response identifier.
+     */
+    public val responseUuid: String?
+        get() = requestOptions.requestContext.responseUuid
 
     /**
      * @suppress
@@ -67,6 +74,7 @@ public class ResponseInfo internal constructor(
     override fun toString(): String {
         return "ResponseInfo(" +
                 "requestOptions=$requestOptions, " +
+                "responseUuid=$responseUuid, " +
                 "coreSearchResponse=$coreSearchResponse, " +
                 "isReproducible=$isReproducible" +
                 ")"

--- a/MapboxSearch/sdk/src/main/java/com/mapbox/search/analytics/FeedbackEvent.kt
+++ b/MapboxSearch/sdk/src/main/java/com/mapbox/search/analytics/FeedbackEvent.kt
@@ -32,6 +32,14 @@ public class FeedbackEvent @JvmOverloads public constructor(
      * Unique ID for identifying several related Mapbox events per session.
      */
     public val sessionId: String? = null,
+
+    /**
+     * Unique feedback ID. If the passed value is null, the id will be generated inside the Search SDK.
+     * Normally SDK users don't have to provide it explicitly.
+     * One of the cases, when users should provide their own id,
+     * is when they want to have associated events in different analytics systems.
+     */
+    public val feedbackId: String? = null,
 ) {
 
     /**
@@ -43,12 +51,14 @@ public class FeedbackEvent @JvmOverloads public constructor(
         text: String? = this.text,
         screenshot: Bitmap? = this.screenshot,
         sessionId: String? = this.sessionId,
+        feedbackId: String? = this.feedbackId,
     ): FeedbackEvent {
         return FeedbackEvent(
             reason = reason,
             text = text,
             screenshot = screenshot,
             sessionId = sessionId,
+            feedbackId = feedbackId,
         )
     }
 
@@ -65,6 +75,7 @@ public class FeedbackEvent @JvmOverloads public constructor(
         if (text != other.text) return false
         if (screenshot != other.screenshot) return false
         if (sessionId != other.sessionId) return false
+        if (feedbackId != other.feedbackId) return false
 
         return true
     }
@@ -77,6 +88,7 @@ public class FeedbackEvent @JvmOverloads public constructor(
         result = 31 * result + (text?.hashCode() ?: 0)
         result = 31 * result + (screenshot?.hashCode() ?: 0)
         result = 31 * result + (sessionId?.hashCode() ?: 0)
+        result = 31 * result + (feedbackId?.hashCode() ?: 0)
         return result
     }
 
@@ -88,7 +100,8 @@ public class FeedbackEvent @JvmOverloads public constructor(
                 "reason='$reason', " +
                 "text=$text, " +
                 "screenshot=$screenshot, " +
-                "sessionId=$sessionId" +
+                "sessionId=$sessionId, " +
+                "feedbackId=$feedbackId" +
                 ")"
     }
 

--- a/MapboxSearch/sdk/src/main/java/com/mapbox/search/analytics/MissingResultFeedbackEvent.kt
+++ b/MapboxSearch/sdk/src/main/java/com/mapbox/search/analytics/MissingResultFeedbackEvent.kt
@@ -29,6 +29,14 @@ public class MissingResultFeedbackEvent @JvmOverloads public constructor(
      * Unique ID for identifying several related Mapbox events per session.
      */
     public val sessionId: String? = null,
+
+    /**
+     * Unique feedback ID. If the passed value is null, the id will be generated inside the Search SDK.
+     * Normally SDK users don't have to provide it explicitly.
+     * One of the cases, when users should provide their own id,
+     * is when they want to have associated events in different analytics systems.
+     */
+    public val feedbackId: String? = null,
 ) {
 
     /**
@@ -40,12 +48,14 @@ public class MissingResultFeedbackEvent @JvmOverloads public constructor(
         text: String? = this.text,
         screenshot: Bitmap? = this.screenshot,
         sessionId: String? = this.sessionId,
+        feedbackId: String? = this.feedbackId,
     ): MissingResultFeedbackEvent {
         return MissingResultFeedbackEvent(
             responseInfo = responseInfo,
             text = text,
             screenshot = screenshot,
             sessionId = sessionId,
+            feedbackId = feedbackId,
         )
     }
 
@@ -62,6 +72,7 @@ public class MissingResultFeedbackEvent @JvmOverloads public constructor(
         if (text != other.text) return false
         if (screenshot != other.screenshot) return false
         if (sessionId != other.sessionId) return false
+        if (feedbackId != other.feedbackId) return false
 
         return true
     }
@@ -74,6 +85,7 @@ public class MissingResultFeedbackEvent @JvmOverloads public constructor(
         result = 31 * result + (text?.hashCode() ?: 0)
         result = 31 * result + (screenshot?.hashCode() ?: 0)
         result = 31 * result + (sessionId?.hashCode() ?: 0)
+        result = 31 * result + (feedbackId?.hashCode() ?: 0)
         return result
     }
 
@@ -85,7 +97,8 @@ public class MissingResultFeedbackEvent @JvmOverloads public constructor(
                 "responseInfo=$responseInfo, " +
                 "text=$text, " +
                 "screenshot=$screenshot, " +
-                "sessionId=$sessionId" +
+                "sessionId=$sessionId, " +
+                "feedbackId=$feedbackId" +
                 ")"
     }
 }

--- a/MapboxSearch/sdk/src/main/java/com/mapbox/search/result/BaseSearchResult.kt
+++ b/MapboxSearch/sdk/src/main/java/com/mapbox/search/result/BaseSearchResult.kt
@@ -12,6 +12,9 @@ internal abstract class BaseSearchResult(
     override val name: String
         get() = originalSearchResult.names[0]
 
+    override val matchingName: String?
+        get() = originalSearchResult.matchingName
+
     override val descriptionText: String?
         get() = originalSearchResult.descriptionAddress
 
@@ -37,10 +40,14 @@ internal abstract class BaseSearchResult(
     override val distanceMeters: Double?
         get() = originalSearchResult.distanceMeters
 
+    override val serverIndex: Int?
+        get() = originalSearchResult.serverIndex
+
     override fun toString(): String {
         return "SearchResult(" +
                 "id='$id', " +
                 "name='$name', " +
+                "matchingName='$matchingName', " +
                 "address='$address', " +
                 "descriptionText='$descriptionText', " +
                 "routablePoints='$routablePoints', " +
@@ -50,8 +57,9 @@ internal abstract class BaseSearchResult(
                 "types='$types', " +
                 "etaMinutes='$etaMinutes', " +
                 "metadata='$metadata', " +
-                "requestOptions='$requestOptions', " +
-                "distanceMeters='$distanceMeters'" +
+                "distanceMeters='$distanceMeters', " +
+                "serverIndex='$serverIndex', " +
+                "requestOptions='$requestOptions'" +
                 ")"
     }
 }

--- a/MapboxSearch/sdk/src/main/java/com/mapbox/search/result/BaseSearchSuggestion.kt
+++ b/MapboxSearch/sdk/src/main/java/com/mapbox/search/result/BaseSearchSuggestion.kt
@@ -10,6 +10,9 @@ internal sealed class BaseSearchSuggestion(
     override val name: String
         get() = originalSearchResult.names[0]
 
+    override val matchingName: String?
+        get() = originalSearchResult.matchingName
+
     override val descriptionText: String?
         get() = originalSearchResult.descriptionAddress
 
@@ -28,9 +31,13 @@ internal sealed class BaseSearchSuggestion(
     override val isBatchResolveSupported: Boolean
         get() = originalSearchResult.action?.multiRetrievable == true
 
+    override val serverIndex: Int?
+        get() = originalSearchResult.serverIndex
+
     protected fun baseToString(): String {
         return "id='$id', " +
                 "name='$name', " +
+                "matchingName='$matchingName', " +
                 "address='$address', " +
                 "descriptionText='$descriptionText', " +
                 "distanceMeters='$distanceMeters', " +
@@ -38,6 +45,7 @@ internal sealed class BaseSearchSuggestion(
                 "type='$type', " +
                 "etaMinutes='$etaMinutes', " +
                 "isBatchResolveSupported='$isBatchResolveSupported', " +
+                "serverIndex='$serverIndex', " +
                 "requestOptions='$requestOptions'"
     }
 

--- a/MapboxSearch/sdk/src/main/java/com/mapbox/search/result/SearchResult.kt
+++ b/MapboxSearch/sdk/src/main/java/com/mapbox/search/result/SearchResult.kt
@@ -27,6 +27,11 @@ public sealed interface SearchResult : Parcelable {
     public val name: String
 
     /**
+     * The feature name, as matched by the search algorithm.
+     */
+    public val matchingName: String?
+
+    /**
      * Additional description for the search result.
      */
     public val descriptionText: String?
@@ -81,6 +86,11 @@ public sealed interface SearchResult : Parcelable {
      * For provided point always returns non-null distance.
      */
     public val distanceMeters: Double?
+
+    /**
+     * Index in response from server.
+     */
+    public val serverIndex: Int?
 }
 
 /**

--- a/MapboxSearch/sdk/src/main/java/com/mapbox/search/result/SearchSuggestion.kt
+++ b/MapboxSearch/sdk/src/main/java/com/mapbox/search/result/SearchSuggestion.kt
@@ -20,6 +20,11 @@ public sealed interface SearchSuggestion : Parcelable {
     public val name: String
 
     /**
+     * The feature name, as matched by the search algorithm.
+     */
+    public val matchingName: String?
+
+    /**
      * Suggestion description.
      */
     public val descriptionText: String?
@@ -59,4 +64,9 @@ public sealed interface SearchSuggestion : Parcelable {
      * Denotes whether this suggestion can be passed as a parameter to a batch selection method of the [com.mapbox.search.SearchEngine].
      */
     public val isBatchResolveSupported: Boolean
+
+    /**
+     * Index in response from server.
+     */
+    public val serverIndex: Int?
 }

--- a/MapboxSearch/sdk/src/test/java/com/mapbox/search/analytics/events/TelemetrySearchEventsFactoryTest.kt
+++ b/MapboxSearch/sdk/src/test/java/com/mapbox/search/analytics/events/TelemetrySearchEventsFactoryTest.kt
@@ -19,10 +19,9 @@ import com.mapbox.search.analytics.FeedbackEvent
 import com.mapbox.search.analytics.MissingResultFeedbackEvent
 import com.mapbox.search.analytics.TelemetrySearchEventsFactory
 import com.mapbox.search.core.CoreSearchEngineInterface
+import com.mapbox.search.location.calculateMapZoom
 import com.mapbox.search.record.FavoriteRecord
 import com.mapbox.search.record.HistoryRecord
-import com.mapbox.search.result.BaseSearchResult
-import com.mapbox.search.result.BaseSearchSuggestion
 import com.mapbox.search.result.GeocodingCompatSearchSuggestion
 import com.mapbox.search.result.IndexableRecordSearchResult
 import com.mapbox.search.result.IndexableRecordSearchResultImpl
@@ -62,6 +61,8 @@ internal class TelemetrySearchEventsFactoryTest {
     private lateinit var mockBitmap: Bitmap
     private lateinit var jsonSerializer: (Any) -> String
 
+    private lateinit var eventsFactory: TelemetrySearchEventsFactory
+
     @BeforeEach
     fun setUp() {
         coreEngine = mockk()
@@ -71,6 +72,15 @@ internal class TelemetrySearchEventsFactoryTest {
 
         every { coreEngine.makeFeedbackEvent(any(), any()) } returns TEST_CORE_RAW_EVENT
         every { jsonSerializer.invoke(ofType<SearchResultsInfo>()) } returns TEST_SEARCH_RESULTS_INFO_JSON
+
+        eventsFactory = createEventsFactory()
+    }
+
+    private fun createEventsFactory(): TelemetrySearchEventsFactory {
+        return TelemetrySearchEventsFactory(
+            TEST_USER_AGENT, viewportProvider, uuidProvider, { coreEngine },
+            eventJsonParser, formattedDateProvider, jsonSerializer, bitmapEncoder
+        )
     }
 
     @TestFactory
@@ -78,15 +88,15 @@ internal class TelemetrySearchEventsFactoryTest {
         Given("TelemetrySearchEventsFactory with mocked dependencies") {
             every { eventJsonParser.parse(TEST_CORE_RAW_EVENT) } answers {
                 SearchFeedbackEvent().apply {
-                    event = "search.feedback"
-                    endpoint = "test-endpoint"
+                    event = SearchFeedbackEvent.EVENT_NAME
+                    endpoint = TEST_ENDPOINT
                     requestParamsJson = TEST_REQUEST_PARAMS_JSON
                 }
             }
 
-            val eventsFactory = createEventsFactory()
+            eventsFactory = createEventsFactory()
 
-            listOf<BaseSearchResult>(TEST_SERVER_SEARCH_RESULT, TEST_LOCAL_SEARCH_RESULT).forEach { searchResult ->
+            listOf(TEST_SERVER_SEARCH_RESULT, TEST_LOCAL_SEARCH_RESULT).forEach { searchResult ->
                 When("Converting ${searchResult.javaClass.simpleName}") {
                     val isCached = searchResult is IndexableRecordSearchResult
                     val feedbackEvent = eventsFactory.createSearchFeedbackEvent(
@@ -109,46 +119,45 @@ internal class TelemetrySearchEventsFactoryTest {
                     Then("Feedback event contains all values") {
                         assertEqualsJsonify(
                             expectedValue = SearchFeedbackEvent().apply {
-                                event = "search.feedback"
+                                event = SearchFeedbackEvent.EVENT_NAME
                                 cached = searchResult is IndexableRecordSearchResult
                                 created = TEST_EVENT_CREATION_DATE
-                                latitude = 53.911334999999994
-                                longitude = 27.55140833333333
-                                resultIndex = 99
-                                orientation = "portrait"
-                                userAgent = "search-sdk-android-test"
-                                queryString = "Paris Eiffel Tower"
-                                language = listOf("fr", "de", "en")
-                                boundingBox = listOf(-170.0, -80.0, 160.0, 70.0)
-                                proximity = listOf(-88.2960988764769, 36.292616502438)
-                                country = listOf("fr", "de")
-                                endpoint = "test-endpoint"
-                                fuzzyMatch = true
-                                limit = 6
-                                types = listOf("POI", "ADDRESS", "POSTCODE")
-                                proximity = listOf(-88.2960988764769, 36.292616502438)
+                                latitude = TEST_USER_LOCATION.latitude()
+                                longitude = TEST_USER_LOCATION.longitude()
+                                resultIndex = TEST_SEARCH_RESULT.serverIndex
+                                orientation = TEST_REQUEST_OPTIONS.requestContext.screenOrientation?.rawValue
+                                userAgent = TEST_USER_AGENT
+                                queryString = searchResult.requestOptions.query
+                                language = searchResult.requestOptions.options.languages?.map { it.code }
+                                boundingBox = searchResult.requestOptions.options.boundingBox?.coordinates()
+                                proximity = searchResult.requestOptions.options.proximity?.coordinates()
+                                country = searchResult.requestOptions.options.countries?.map { it.code }
+                                endpoint = TEST_ENDPOINT
+                                fuzzyMatch = searchResult.requestOptions.options.fuzzyMatch
+                                limit = searchResult.requestOptions.options.limit
+                                types = searchResult.requestOptions.options.types?.map { it.name }
                                 feedbackReason = "Missing routable point"
                                 feedbackText = "Fix, please!"
-                                selectedItemName = "Tour Eiffel"
-                                keyboardLocale = "de"
-                                mapZoom = 2.0f
-                                mapCenterLatitude = 22.5
-                                mapCenterLongitude = 45.0
+                                selectedItemName = searchResult.originalSearchResult.names.first()
+                                keyboardLocale = TEST_LOCALE.language
+                                mapZoom = calculateMapZoom(TEST_VIEWPORT)
+                                mapCenterLatitude = TEST_VIEWPORT.centerLatitude()
+                                mapCenterLongitude = TEST_VIEWPORT.centerLongitude()
                                 resultId = when (isCached) {
                                     true -> null
-                                    false -> "Y2aAgIL8TAA=.42eAgMSCTN2C_Ezd4tSisszkVAA=.U2aAgLT80qLiwtLEolQ9U8NEIxMT01RTA0PLZAuDJFMzS2OTZHNTAA=="
+                                    false -> searchResult.originalSearchResult.id
                                 }
                                 sessionIdentifier = when (isCached) {
-                                    true -> "<Not available>"
-                                    false -> "test-session-id"
+                                    true -> NOT_AVAILABLE_SESSION_ID
+                                    false -> TEST_SESSION_ID
                                 }
-                                responseUuid = "test-response-uuid"
-                                feedbackId = "test-generated-uuid"
+                                responseUuid = TEST_RESPONSE_UUID
+                                feedbackId = TEST_UUID
                                 if (BuildConfig.DEBUG) {
                                     isTest = true
                                 }
                                 screenshot = TEST_ENCODED_BITMAP
-                                resultCoordinates = listOf(2.294423282146454, 48.85825817805569)
+                                resultCoordinates = searchResult.coordinate?.coordinates()
                                 requestParamsJson = TEST_REQUEST_PARAMS_JSON
                                 appMetadata = AppMetadata(
                                     name = null,
@@ -157,7 +166,7 @@ internal class TelemetrySearchEventsFactoryTest {
                                     sessionId = TEST_SESSION_ID
                                 )
                                 searchResultsJson = TEST_SEARCH_RESULTS_INFO_JSON
-                                schema = "search.feedback-2.3"
+                                schema = SEARCH_FEEDBACK_SCHEMA_VERSION
                             },
                             actualValue = feedbackEvent
                         )
@@ -172,15 +181,15 @@ internal class TelemetrySearchEventsFactoryTest {
         Given("TelemetrySearchEventsFactory with mocked dependencies") {
             every { eventJsonParser.parse(TEST_CORE_RAW_EVENT) } answers {
                 SearchFeedbackEvent().apply {
-                    event = "search.feedback"
-                    endpoint = "test-endpoint"
+                    event = SearchFeedbackEvent.EVENT_NAME
+                    endpoint = TEST_ENDPOINT
                     requestParamsJson = TEST_REQUEST_PARAMS_JSON
                 }
             }
 
-            val eventsFactory = createEventsFactory()
+            eventsFactory = createEventsFactory()
 
-            listOf<BaseSearchSuggestion>(
+            listOf(
                 TEST_SERVER_SEARCH_SUGGESTION,
                 TEST_LOCAL_SEARCH_SUGGESTION,
                 TEST_GEOCODING_COMPAT_SEARCH_SUGGESTION
@@ -204,50 +213,49 @@ internal class TelemetrySearchEventsFactoryTest {
                     Then("Feedback event contains all values") {
                         assertEqualsJsonify(
                             expectedValue = SearchFeedbackEvent().apply {
-                                event = "search.feedback"
+                                event = SearchFeedbackEvent.EVENT_NAME
                                 cached = searchSuggestion is IndexableRecordSearchSuggestion
                                 created = TEST_EVENT_CREATION_DATE
-                                latitude = 53.911334999999994
-                                longitude = 27.55140833333333
-                                resultIndex = 99
-                                orientation = "portrait"
-                                userAgent = "search-sdk-android-test"
-                                queryString = "Paris Eiffel Tower"
-                                language = listOf("fr", "de", "en")
-                                boundingBox = listOf(-170.0, -80.0, 160.0, 70.0)
-                                proximity = listOf(-88.2960988764769, 36.292616502438)
-                                country = listOf("fr", "de")
-                                endpoint = "test-endpoint"
-                                fuzzyMatch = true
-                                limit = 6
-                                types = listOf("POI", "ADDRESS", "POSTCODE")
-                                proximity = listOf(-88.2960988764769, 36.292616502438)
+                                latitude = TEST_USER_LOCATION.latitude()
+                                longitude = TEST_USER_LOCATION.longitude()
+                                resultIndex = searchSuggestion.serverIndex
+                                orientation = TEST_REQUEST_OPTIONS.requestContext.screenOrientation?.rawValue
+                                userAgent = TEST_USER_AGENT
+                                queryString = searchSuggestion.requestOptions.query
+                                language = searchSuggestion.requestOptions.options.languages?.map { it.code }
+                                boundingBox = searchSuggestion.requestOptions.options.boundingBox?.coordinates()
+                                proximity = searchSuggestion.requestOptions.options.proximity?.coordinates()
+                                country = searchSuggestion.requestOptions.options.countries?.map { it.code }
+                                endpoint = TEST_ENDPOINT
+                                fuzzyMatch = searchSuggestion.requestOptions.options.fuzzyMatch
+                                limit = searchSuggestion.requestOptions.options.limit
+                                types = searchSuggestion.requestOptions.options.types?.map { it.name }
                                 feedbackReason = "Missing routable point"
                                 feedbackText = "Fix, please!"
-                                selectedItemName = "Tour Eiffel"
-                                mapZoom = 2.0f
-                                mapCenterLatitude = 22.5
-                                mapCenterLongitude = 45.0
-                                keyboardLocale = "de"
+                                selectedItemName = searchSuggestion.originalSearchResult.names.first()
+                                mapZoom = calculateMapZoom(TEST_VIEWPORT)
+                                mapCenterLatitude = TEST_VIEWPORT.centerLatitude()
+                                mapCenterLongitude = TEST_VIEWPORT.centerLongitude()
+                                keyboardLocale = TEST_LOCALE.language
                                 resultId = when (isCached) {
                                     true -> null
-                                    false -> "Y2aAgIL8TAA=.42eAgMSCTN2C_Ezd4tSisszkVAA=.U2aAgLT80qLiwtLEolQ9U8NEIxMT01RTA0PLZAuDJFMzS2OTZHNTAA=="
+                                    false -> searchSuggestion.originalSearchResult.id
                                 }
                                 sessionIdentifier = when (isCached) {
-                                    true -> "<Not available>"
-                                    false -> "test-session-id"
+                                    true -> NOT_AVAILABLE_SESSION_ID
+                                    false -> TEST_SESSION_ID
                                 }
-                                responseUuid = "test-response-uuid"
-                                feedbackId = "test-generated-uuid"
+                                responseUuid = TEST_RESPONSE_UUID
+                                feedbackId = TEST_UUID
                                 if (BuildConfig.DEBUG) {
                                     isTest = true
                                 }
                                 screenshot = TEST_ENCODED_BITMAP
-                                resultCoordinates = listOf(2.294423282146454, 48.85825817805569)
+                                resultCoordinates = searchSuggestion.originalSearchResult.center?.coordinates()
                                 requestParamsJson = TEST_REQUEST_PARAMS_JSON
                                 appMetadata = null
                                 searchResultsJson = null
-                                schema = "search.feedback-2.3"
+                                schema = SEARCH_FEEDBACK_SCHEMA_VERSION
                             },
                             actualValue = feedbackEvent
                         )
@@ -262,12 +270,12 @@ internal class TelemetrySearchEventsFactoryTest {
         Given("TelemetrySearchEventsFactory with mocked dependencies") {
             every { eventJsonParser.parse(TEST_CORE_RAW_EVENT) } answers {
                 SearchFeedbackEvent().apply {
-                    event = "search.feedback"
-                    endpoint = "test-endpoint"
+                    event = SearchFeedbackEvent.EVENT_NAME
+                    endpoint = TEST_ENDPOINT
                 }
             }
 
-            val eventsFactory = createEventsFactory()
+            eventsFactory = createEventsFactory()
 
             When("Converting FavoriteRecord") {
                 val feedbackEvent = eventsFactory.createSearchFeedbackEvent(
@@ -282,31 +290,31 @@ internal class TelemetrySearchEventsFactoryTest {
                 Then("Feedback event contains all values") {
                     assertEqualsJsonify(
                         expectedValue = SearchFeedbackEvent().apply {
-                            event = "search.feedback"
+                            event = SearchFeedbackEvent.EVENT_NAME
                             cached = true
                             created = TEST_EVENT_CREATION_DATE
-                            latitude = 53.911334999999994
-                            longitude = 27.55140833333333
+                            latitude = TEST_USER_LOCATION.latitude()
+                            longitude = TEST_USER_LOCATION.longitude()
                             resultIndex = -1
-                            userAgent = "search-sdk-android-test"
+                            userAgent = TEST_USER_AGENT
                             queryString = ""
                             feedbackReason = "Missing routable point"
                             feedbackText = "Fix, please!"
-                            selectedItemName = "22 Baker street"
-                            mapZoom = 2.0f
-                            mapCenterLatitude = 22.5
-                            mapCenterLongitude = 45.0
-                            sessionIdentifier = "<Not available>"
-                            feedbackId = "test-generated-uuid"
+                            selectedItemName = TEST_FAVORITE_RECORD.address?.formattedAddress(SearchAddress.FormatStyle.Full)
+                            mapZoom = calculateMapZoom(TEST_VIEWPORT)
+                            mapCenterLatitude = TEST_VIEWPORT.centerLatitude()
+                            mapCenterLongitude = TEST_VIEWPORT.centerLongitude()
+                            sessionIdentifier = NOT_AVAILABLE_SESSION_ID
+                            feedbackId = TEST_UUID
                             if (BuildConfig.DEBUG) {
                                 isTest = true
                             }
                             screenshot = TEST_ENCODED_BITMAP
-                            resultCoordinates = listOf(2.294423282146454, 48.85825817805569)
+                            resultCoordinates = TEST_FAVORITE_RECORD.coordinate.coordinates()
                             requestParamsJson = null
                             appMetadata = null
                             searchResultsJson = null
-                            schema = "search.feedback-2.3"
+                            schema = SEARCH_FEEDBACK_SCHEMA_VERSION
                         },
                         actualValue = feedbackEvent
                     )
@@ -326,30 +334,30 @@ internal class TelemetrySearchEventsFactoryTest {
                 Then("Feedback event contains all values") {
                     assertEqualsJsonify(
                         expectedValue = SearchFeedbackEvent().apply {
-                            event = "search.feedback"
+                            event = SearchFeedbackEvent.EVENT_NAME
                             cached = true
                             created = TEST_EVENT_CREATION_DATE
-                            latitude = 53.911334999999994
-                            longitude = 27.55140833333333
+                            latitude = TEST_USER_LOCATION.latitude()
+                            longitude = TEST_USER_LOCATION.longitude()
                             resultIndex = -1
-                            userAgent = "search-sdk-android-test"
+                            userAgent = TEST_USER_AGENT
                             queryString = ""
                             feedbackReason = "Missing routable point"
                             feedbackText = "Fix, please!"
-                            selectedItemName = "<No address>"
-                            mapZoom = 2.0f
-                            mapCenterLatitude = 22.5
-                            mapCenterLongitude = 45.0
-                            sessionIdentifier = "<Not available>"
-                            feedbackId = "test-generated-uuid"
+                            selectedItemName = NO_ADDRESS_PLACEHOLDER
+                            mapZoom = calculateMapZoom(TEST_VIEWPORT)
+                            mapCenterLatitude = TEST_VIEWPORT.centerLatitude()
+                            mapCenterLongitude = TEST_VIEWPORT.centerLongitude()
+                            sessionIdentifier = NOT_AVAILABLE_SESSION_ID
+                            feedbackId = TEST_UUID
                             if (BuildConfig.DEBUG) {
                                 isTest = true
                             }
                             screenshot = TEST_ENCODED_BITMAP
-                            resultCoordinates = listOf(2.294423282146454, 48.85825817805569)
+                            resultCoordinates = TEST_HISTORY_RECORD.coordinate?.coordinates()
                             requestParamsJson = null
                             appMetadata = null
-                            schema = "search.feedback-2.3"
+                            schema = SEARCH_FEEDBACK_SCHEMA_VERSION
                         },
                         actualValue = feedbackEvent
                     )
@@ -363,13 +371,13 @@ internal class TelemetrySearchEventsFactoryTest {
         Given("TelemetrySearchEventsFactory with mocked dependencies") {
             every { eventJsonParser.parse(TEST_CORE_RAW_EVENT) } answers {
                 SearchFeedbackEvent().apply {
-                    event = "search.feedback"
-                    endpoint = "test-endpoint"
+                    event = SearchFeedbackEvent.EVENT_NAME
+                    endpoint = TEST_ENDPOINT
                     requestParamsJson = TEST_REQUEST_PARAMS_JSON
                 }
             }
 
-            val eventsFactory = createEventsFactory()
+            eventsFactory = createEventsFactory()
 
             When("Converting ResponseInfo") {
                 val feedbackEvent = eventsFactory.createSearchFeedbackEvent(
@@ -391,33 +399,32 @@ internal class TelemetrySearchEventsFactoryTest {
                 Then("Feedback event contains all values") {
                     assertEqualsJsonify(
                         expectedValue = SearchFeedbackEvent().apply {
-                            event = "search.feedback"
+                            event = SearchFeedbackEvent.EVENT_NAME
                             created = TEST_EVENT_CREATION_DATE
-                            latitude = 53.911334999999994
-                            longitude = 27.55140833333333
+                            latitude = TEST_USER_LOCATION.latitude()
+                            longitude = TEST_USER_LOCATION.longitude()
                             resultIndex = -1
-                            orientation = "portrait"
-                            userAgent = "search-sdk-android-test"
-                            queryString = "Paris Eiffel Tower"
-                            language = listOf("fr", "de", "en")
-                            boundingBox = listOf(-170.0, -80.0, 160.0, 70.0)
-                            proximity = listOf(-88.2960988764769, 36.292616502438)
-                            country = listOf("fr", "de")
-                            endpoint = "test-endpoint"
+                            orientation = TEST_REQUEST_OPTIONS.requestContext.screenOrientation?.rawValue
+                            userAgent = TEST_USER_AGENT
+                            queryString = TEST_REQUEST_OPTIONS.query
+                            language = TEST_SEARCH_OPTIONS.languages?.map { it.code }
+                            boundingBox = TEST_SEARCH_OPTIONS.boundingBox?.coordinates()
+                            proximity = TEST_SEARCH_OPTIONS.proximity?.coordinates()
+                            country = TEST_SEARCH_OPTIONS.countries?.map { it.code }
+                            endpoint = TEST_ENDPOINT
                             fuzzyMatch = true
                             limit = 6
-                            types = listOf("POI", "ADDRESS", "POSTCODE")
-                            proximity = listOf(-88.2960988764769, 36.292616502438)
+                            types = TEST_SEARCH_OPTIONS.types?.map { it.name }
                             feedbackReason = "cannot_find"
                             feedbackText = "Please, add Paris to search results!"
                             selectedItemName = ""
-                            keyboardLocale = "de"
-                            mapZoom = 2.0f
-                            mapCenterLatitude = 22.5
-                            mapCenterLongitude = 45.0
-                            sessionIdentifier = "test-session-id"
-                            responseUuid = "test-response-uuid"
-                            feedbackId = "test-generated-uuid"
+                            keyboardLocale = TEST_LOCALE.language
+                            mapZoom = calculateMapZoom(TEST_VIEWPORT)
+                            mapCenterLatitude = TEST_VIEWPORT.centerLatitude()
+                            mapCenterLongitude = TEST_VIEWPORT.centerLongitude()
+                            sessionIdentifier = TEST_SESSION_ID
+                            responseUuid = TEST_RESPONSE_UUID
+                            feedbackId = TEST_UUID
                             if (BuildConfig.DEBUG) {
                                 isTest = true
                             }
@@ -430,7 +437,7 @@ internal class TelemetrySearchEventsFactoryTest {
                                 sessionId = TEST_SESSION_ID
                             )
                             searchResultsJson = TEST_SEARCH_RESULTS_INFO_JSON
-                            schema = "search.feedback-2.3"
+                            schema = SEARCH_FEEDBACK_SCHEMA_VERSION
                         },
                         actualValue = feedbackEvent
                     )
@@ -444,7 +451,7 @@ internal class TelemetrySearchEventsFactoryTest {
         Given("TelemetrySearchEventsFactory with mocked dependencies") {
             val eventsFactory = createEventsFactory()
             val cachedSearchEvent = SearchFeedbackEvent().apply {
-                event = "search.feedback"
+                event = SearchFeedbackEvent.EVENT_NAME
                 selectedItemName = "cached-item"
                 sessionIdentifier = "cached-session-id"
                 resultIndex = -1
@@ -467,22 +474,22 @@ internal class TelemetrySearchEventsFactoryTest {
                 Then("Feedback event was properly created from raw event") {
                     assertEqualsJsonify(
                         expectedValue = SearchFeedbackEvent().apply {
-                            event = "search.feedback"
+                            event = SearchFeedbackEvent.EVENT_NAME
                             cached = true
                             created = TEST_EVENT_CREATION_DATE
-                            latitude = 53.911334999999994
-                            longitude = 27.55140833333333
+                            latitude = TEST_USER_LOCATION.latitude()
+                            longitude = TEST_USER_LOCATION.longitude()
                             resultIndex = -1
-                            userAgent = "search-sdk-android-test"
+                            userAgent = TEST_USER_AGENT
                             queryString = "cached query"
                             feedbackReason = "Missing routable point"
                             feedbackText = "Fix, please!"
                             selectedItemName = "cached-item"
-                            mapZoom = 2.0f
-                            mapCenterLatitude = 22.5
-                            mapCenterLongitude = 45.0
+                            mapZoom = calculateMapZoom(TEST_VIEWPORT)
+                            mapCenterLatitude = TEST_VIEWPORT.centerLatitude()
+                            mapCenterLongitude = TEST_VIEWPORT.centerLongitude()
                             sessionIdentifier = "cached-session-id"
-                            feedbackId = "test-generated-uuid"
+                            feedbackId = TEST_UUID
                             if (BuildConfig.DEBUG) {
                                 isTest = true
                             }
@@ -503,13 +510,6 @@ internal class TelemetrySearchEventsFactoryTest {
         }
     }
 
-    private fun createEventsFactory(): TelemetrySearchEventsFactory {
-        return TelemetrySearchEventsFactory(
-            TEST_USER_AGENT, viewportProvider, uuidProvider, { coreEngine },
-            eventJsonParser, formattedDateProvider, jsonSerializer, bitmapEncoder
-        )
-    }
-
     private companion object {
 
         const val TEST_USER_AGENT = "search-sdk-android-test"
@@ -524,6 +524,13 @@ internal class TelemetrySearchEventsFactoryTest {
         val TEST_USER_PROXIMITY: Point = Point.fromLngLat(-88.2960988764769, 36.292616502438)
         val TEST_ORIGIN_LOCATION: Point = Point.fromLngLat(-88.3, 36.3)
         val TEST_VIEWPORT: BoundingBox = BoundingBox.fromLngLats(0.0, 0.0, 90.0, 45.0)
+        val TEST_LOCALE: Locale = Locale.GERMANY
+        const val TEST_RESPONSE_UUID = "test-response-uuid"
+        const val TEST_ENDPOINT = "test-endpoint"
+
+        const val NOT_AVAILABLE_SESSION_ID = "<Not available>"
+        const val SEARCH_FEEDBACK_SCHEMA_VERSION = "search.feedback-2.3"
+        const val NO_ADDRESS_PLACEHOLDER = "<No address>"
 
         val TEST_SEARCH_OPTIONS = SearchOptions(
             proximity = TEST_USER_PROXIMITY,
@@ -549,9 +556,9 @@ internal class TelemetrySearchEventsFactoryTest {
             options = TEST_SEARCH_OPTIONS,
             requestContext = SearchRequestContext(
                 apiType = ApiType.SBS,
-                keyboardLocale = Locale.GERMANY,
+                keyboardLocale = TEST_LOCALE,
                 screenOrientation = ScreenOrientation.PORTRAIT,
-                responseUuid = "test-response-uuid"
+                responseUuid = TEST_RESPONSE_UUID
             )
         )
 
@@ -594,7 +601,7 @@ internal class TelemetrySearchEventsFactoryTest {
         )
 
         val TEST_FAVORITE_RECORD = FavoriteRecord(
-            id = TEST_UUID,
+            id = "test-favorite-record-id",
             name = "Test Local Favorite Name",
             coordinate = Point.fromLngLat(2.294423282146454, 48.85825817805569),
             descriptionText = "Test description text",
@@ -623,7 +630,7 @@ internal class TelemetrySearchEventsFactoryTest {
         )
 
         val TEST_HISTORY_RECORD = HistoryRecord(
-            id = TEST_UUID,
+            id = "test-history-record-id",
             name = "Test Local History Name",
             coordinate = Point.fromLngLat(2.294423282146454, 48.85825817805569),
             descriptionText = "Test description text",
@@ -635,5 +642,11 @@ internal class TelemetrySearchEventsFactoryTest {
             categories = emptyList(),
             timestamp = 123_456_789L
         )
+
+        private fun BoundingBox.coordinates(): List<Double> = listOf(west(), south(), east(), north())
+
+        private fun BoundingBox.centerLatitude() = (north() + south()) / 2
+
+        private fun BoundingBox.centerLongitude() = (east() + west()) / 2
     }
 }

--- a/MapboxSearch/sdk/src/test/java/com/mapbox/search/analytics/events/TelemetrySearchEventsFactoryTest.kt
+++ b/MapboxSearch/sdk/src/test/java/com/mapbox/search/analytics/events/TelemetrySearchEventsFactoryTest.kt
@@ -96,8 +96,8 @@ internal class TelemetrySearchEventsFactoryTest {
 
             eventsFactory = createEventsFactory()
 
-            listOf(TEST_SERVER_SEARCH_RESULT, TEST_LOCAL_SEARCH_RESULT).forEach { searchResult ->
-                When("Converting ${searchResult.javaClass.simpleName}") {
+            When("Converting search results with default feedback id") {
+                listOf(TEST_SERVER_SEARCH_RESULT, TEST_LOCAL_SEARCH_RESULT).forEach { searchResult ->
                     val isCached = searchResult is IndexableRecordSearchResult
                     val feedbackEvent = eventsFactory.createSearchFeedbackEvent(
                         searchResult.originalSearchResult,
@@ -116,7 +116,7 @@ internal class TelemetrySearchEventsFactoryTest {
                         isCached = isCached
                     )
 
-                    Then("Feedback event contains all values") {
+                    Then("Feedback event for ${searchResult.javaClass.simpleName} contains all values") {
                         assertEqualsJsonify(
                             expectedValue = SearchFeedbackEvent().apply {
                                 event = SearchFeedbackEvent.EVENT_NAME
@@ -173,6 +173,30 @@ internal class TelemetrySearchEventsFactoryTest {
                     }
                 }
             }
+
+            When("Converting search results with overridden feedback id") {
+                val overriddenFeedbackId = "overridden-feedback-id"
+
+                val feedbackEvent = eventsFactory.createSearchFeedbackEvent(
+                    TEST_SERVER_SEARCH_RESULT.originalSearchResult,
+                    TEST_SERVER_SEARCH_RESULT.requestOptions,
+                    createTestCoreSearchResponse(
+                        results = listOf(TEST_SEARCH_RESULT.mapToCore())
+                    ),
+                    TEST_USER_LOCATION,
+                    isReproducible = true,
+                    event = FeedbackEvent(
+                        reason = "Missing routable point",
+                        text = "Fix, please!",
+                        screenshot = mockBitmap,
+                        sessionId = TEST_SESSION_ID,
+                        feedbackId = overriddenFeedbackId,
+                    ),
+                    isCached = false
+                )
+
+                Then("Feedback id should be $overriddenFeedbackId", overriddenFeedbackId, feedbackEvent.feedbackId)
+            }
         }
     }
 
@@ -189,12 +213,12 @@ internal class TelemetrySearchEventsFactoryTest {
 
             eventsFactory = createEventsFactory()
 
-            listOf(
-                TEST_SERVER_SEARCH_SUGGESTION,
-                TEST_LOCAL_SEARCH_SUGGESTION,
-                TEST_GEOCODING_COMPAT_SEARCH_SUGGESTION
-            ).forEach { searchSuggestion ->
-                When("Converting ${searchSuggestion.javaClass.simpleName}") {
+            When("Converting search suggestions with default feedback id") {
+                listOf(
+                    TEST_SERVER_SEARCH_SUGGESTION,
+                    TEST_LOCAL_SEARCH_SUGGESTION,
+                    TEST_GEOCODING_COMPAT_SEARCH_SUGGESTION
+                ).forEach { searchSuggestion ->
                     val isCached = searchSuggestion is IndexableRecordSearchSuggestion
                     val feedbackEvent = eventsFactory.createSearchFeedbackEvent(
                         searchSuggestion.originalSearchResult,
@@ -210,7 +234,7 @@ internal class TelemetrySearchEventsFactoryTest {
                         isCached = isCached
                     )
 
-                    Then("Feedback event contains all values") {
+                    Then("Feedback event for ${searchSuggestion.javaClass.simpleName} contains all values") {
                         assertEqualsJsonify(
                             expectedValue = SearchFeedbackEvent().apply {
                                 event = SearchFeedbackEvent.EVENT_NAME
@@ -262,6 +286,27 @@ internal class TelemetrySearchEventsFactoryTest {
                     }
                 }
             }
+
+            When("Converting search suggestion with overridden feedback id") {
+                val overriddenFeedbackId = "overridden-feedback-id"
+
+                val feedbackEvent = eventsFactory.createSearchFeedbackEvent(
+                    TEST_SERVER_SEARCH_SUGGESTION.originalSearchResult,
+                    TEST_SERVER_SEARCH_SUGGESTION.requestOptions,
+                    null,
+                    TEST_USER_LOCATION,
+                    isReproducible = true,
+                    event = FeedbackEvent(
+                        reason = "Missing routable point",
+                        text = "Fix, please!",
+                        screenshot = mockBitmap,
+                        feedbackId = overriddenFeedbackId,
+                    ),
+                    isCached = false
+                )
+
+                Then("Feedback id should be", overriddenFeedbackId, feedbackEvent.feedbackId)
+            }
         }
     }
 
@@ -277,7 +322,7 @@ internal class TelemetrySearchEventsFactoryTest {
 
             eventsFactory = createEventsFactory()
 
-            When("Converting FavoriteRecord") {
+            When("Converting FavoriteRecord with default feedback id") {
                 val feedbackEvent = eventsFactory.createSearchFeedbackEvent(
                     TEST_FAVORITE_RECORD,
                     FeedbackEvent(
@@ -321,7 +366,23 @@ internal class TelemetrySearchEventsFactoryTest {
                 }
             }
 
-            When("Converting HistoryRecord") {
+            When("Converting FavoriteRecord with overridden feedback id") {
+                val overriddenFeedbackId = "overridden-feedback-id"
+
+                val feedbackEvent = eventsFactory.createSearchFeedbackEvent(
+                    TEST_FAVORITE_RECORD,
+                    FeedbackEvent(
+                        reason = "Missing routable point",
+                        text = "Fix, please!",
+                        screenshot = mockBitmap,
+                        feedbackId = overriddenFeedbackId,
+                    ),
+                    TEST_USER_LOCATION
+                )
+                Then("Feedback id should be $overriddenFeedbackId", overriddenFeedbackId, feedbackEvent.feedbackId)
+            }
+
+            When("Converting HistoryRecord with default feedback id") {
                 val feedbackEvent = eventsFactory.createSearchFeedbackEvent(
                     TEST_HISTORY_RECORD,
                     FeedbackEvent(
@@ -363,6 +424,22 @@ internal class TelemetrySearchEventsFactoryTest {
                     )
                 }
             }
+
+            When("Converting HistoryRecord with overridden feedback id") {
+                val overriddenFeedbackId = "overridden-feedback-id"
+
+                val feedbackEvent = eventsFactory.createSearchFeedbackEvent(
+                    TEST_HISTORY_RECORD,
+                    FeedbackEvent(
+                        reason = "Missing routable point",
+                        text = "Fix, please!",
+                        screenshot = mockBitmap,
+                        feedbackId = overriddenFeedbackId,
+                    ),
+                    TEST_USER_LOCATION
+                )
+                Then("Feedback id should be $overriddenFeedbackId", overriddenFeedbackId, feedbackEvent.feedbackId)
+            }
         }
     }
 
@@ -379,7 +456,7 @@ internal class TelemetrySearchEventsFactoryTest {
 
             eventsFactory = createEventsFactory()
 
-            When("Converting ResponseInfo") {
+            When("Converting ResponseInfo with default feedback id") {
                 val feedbackEvent = eventsFactory.createSearchFeedbackEvent(
                     MissingResultFeedbackEvent(
                         ResponseInfo(
@@ -442,6 +519,29 @@ internal class TelemetrySearchEventsFactoryTest {
                         actualValue = feedbackEvent
                     )
                 }
+            }
+
+            When("Converting ResponseInfo with overridden feedback id") {
+                val overriddenFeedbackId = "overridden-feedback-id"
+
+                val feedbackEvent = eventsFactory.createSearchFeedbackEvent(
+                    MissingResultFeedbackEvent(
+                        ResponseInfo(
+                            requestOptions = TEST_REQUEST_OPTIONS,
+                            coreSearchResponse = createTestCoreSearchResponse(
+                                results = listOf(TEST_SEARCH_RESULT.mapToCore())
+                            ),
+                            isReproducible = true,
+                        ),
+                        "Please, add Paris to search results!",
+                        sessionId = TEST_SESSION_ID,
+                        screenshot = mockBitmap,
+                        feedbackId = overriddenFeedbackId,
+                    ),
+                    TEST_USER_LOCATION
+                )
+
+                Then("Feedback id should be $overriddenFeedbackId", overriddenFeedbackId, feedbackEvent.feedbackId)
             }
         }
     }


### PR DESCRIPTION
<!-- ⚠️ TEMPLATE ⚠️ -->
<!-- Template for GitHub PR descriptions. Use it as a guide on how to describe your work. Feel free to remove any section when you're opening a PR if you think it does not apply for your committed changes. -->

### Description
- New properties `SearchSuggestion.matchingName`, `SearchSuggestion.serverIndex`, `SearchResult.matchingName`, `SearchResult.serverIndex`, `ResponseInfo.responseUuid`.
- `FeedbackEvent.feedbackId` and `MissingResultFeedbackEvent.feedbackId`.


### Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have updated the `CHANGELOG` including this PR (where applicable)
- [x] I have run tests and automatic checks locally
- [ ] I have run `pitest` check locally and checked that the coverage increased (or didn't change) or decreased insignificantly
- [x] I have made corresponding changes to the documentation (where applicable)
- [x] I have grouped commits logically or I promise to squash my commits before merge
