### PR TITLE
Conductor version bump; Tests for search limit; Common default search options

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -708,6 +708,12 @@ License: [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENS
 
 ===========================================================================
 
+Mapbox Search Android uses portions of the SavedState Kotlin Extensions.  
+URL: [https://developer.android.com/jetpack/androidx/releases/savedstate#1.1.0](https://developer.android.com/jetpack/androidx/releases/savedstate#1.1.0)  
+License: [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+===========================================================================
+
 Mapbox Search Android uses portions of the VersionedParcelable.  
 URL: [http://developer.android.com/tools/extras/support-library.html](http://developer.android.com/tools/extras/support-library.html)  
 License: [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)

--- a/MapboxSearch/gradle.properties
+++ b/MapboxSearch/gradle.properties
@@ -16,7 +16,7 @@ org.gradle.jvmargs=-Xmx1536m
 # https://developer.android.com/topic/libraries/support-library/androidx-rn
 android.useAndroidX=true
 # Automatically convert third-party libraries to use AndroidX
-android.enableJetifier=true
+android.enableJetifier=false
 # Kotlin code style for this project: "official" or "obsolete":
 kotlin.code.style=official
 

--- a/MapboxSearch/gradle/versions.gradle
+++ b/MapboxSearch/gradle/versions.gradle
@@ -22,7 +22,7 @@ ext {
     okhttp_interceptor_version = '4.9.0'
     okhttp_mock_version = '1.5.0'
 
-    conductor_version = "2.1.5"
+    conductor_version = "3.1.2"
 
     junit_version = '4.13.2'
     android_x_test_runner_version = '1.4.0'

--- a/MapboxSearch/sdk/src/main/java/com/mapbox/search/CategorySearchOptions.kt
+++ b/MapboxSearch/sdk/src/main/java/com/mapbox/search/CategorySearchOptions.kt
@@ -48,7 +48,8 @@ public class CategorySearchOptions @JvmOverloads public constructor(
     public val languages: List<Language>? = defaultSearchOptionsLanguage(),
 
     /**
-     * Specify the maximum number of results to return. The maximum supported is 10.
+     * Specify the maximum number of results to return, including results from [com.mapbox.search.record.IndexableDataProvider].
+     * The maximum number of search results returned from the server is 10.
      */
     public val limit: Int? = null,
 

--- a/MapboxSearch/sdk/src/main/java/com/mapbox/search/SearchOptions.kt
+++ b/MapboxSearch/sdk/src/main/java/com/mapbox/search/SearchOptions.kt
@@ -52,7 +52,8 @@ public class SearchOptions @JvmOverloads public constructor(
     public val languages: List<Language>? = defaultSearchOptionsLanguage(),
 
     /**
-     * Specify the maximum number of results to return. The maximum supported is 10.
+     * Specify the maximum number of results to return, including results from [com.mapbox.search.record.IndexableDataProvider].
+     * The maximum number of search results returned from the server is 10.
      */
     public val limit: Int? = null,
 

--- a/MapboxSearch/sdk/src/sharedTest/java/com/mapbox/search/tests_support/BlockingSearchCallback.kt
+++ b/MapboxSearch/sdk/src/sharedTest/java/com/mapbox/search/tests_support/BlockingSearchCallback.kt
@@ -30,6 +30,9 @@ internal class BlockingSearchCallback : SearchCallback {
     }
 
     sealed class SearchEngineResult {
+
+        fun requireResults() = (this as Results).results
+
         data class Results(val results: List<SearchResult>, val responseInfo: ResponseInfo) : SearchEngineResult()
         data class Error(val e: Exception) : SearchEngineResult()
     }

--- a/MapboxSearch/ui/src/main/java/com/mapbox/search/ui/view/SearchBottomSheetView.kt
+++ b/MapboxSearch/ui/src/main/java/com/mapbox/search/ui/view/SearchBottomSheetView.kt
@@ -172,6 +172,7 @@ public class SearchBottomSheetView @JvmOverloads constructor(
 
         router = Conductor.attachRouter(context.unwrapActivityOrNull()!!, screensContainer, savedInstanceState)
 
+        // TODO(https://github.com/mapbox/mapbox-search-android/issues/16) replace Conductor with more suitable for UI SDK case mechanism
         // Regardless of passed savedInstanceState, conductor stores it's state during activity lifecycle.
         // If savedInstanceState is null here and router already has a root controller,
         // most probably this is an integration bug (developers didn't provide savedInstanceState) or

--- a/MapboxSearch/ui/src/main/java/com/mapbox/search/ui/view/SearchResultsView.kt
+++ b/MapboxSearch/ui/src/main/java/com/mapbox/search/ui/view/SearchResultsView.kt
@@ -72,10 +72,7 @@ public class SearchResultsView @JvmOverloads constructor(
     /**
      * [SearchOptions] that will be used for search requests.
      */
-    public var defaultSearchOptions: SearchOptions = SearchOptions(
-        limit = GlobalViewPreferences.SEARCH_LIMIT,
-        requestDebounce = GlobalViewPreferences.DEFAULT_REQUESTS_DEBOUNCE_MILLIS
-    )
+    public var defaultSearchOptions: SearchOptions = GlobalViewPreferences.DEFAULT_SEARCH_OPTIONS
 
     private var commonSearchViewConfiguration = CommonSearchViewConfiguration()
     private var isInitialized = false

--- a/MapboxSearch/ui/src/main/java/com/mapbox/search/ui/view/category/CategorySuggestionSearchViewController.kt
+++ b/MapboxSearch/ui/src/main/java/com/mapbox/search/ui/view/category/CategorySuggestionSearchViewController.kt
@@ -36,7 +36,7 @@ internal class CategorySuggestionSearchViewController : BaseSearchController {
         configuration = requireNotNull(bundle.getParcelable(BUNDLE_KEY_CONFIGURATION))
     }
 
-    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup): View {
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup, savedViewState: Bundle?): View {
         return CategorySuggestionSearchView(container.context).apply {
             init(searchSuggestion, configuration)
             onSearchResultClickListener = { searchResult, responseInfo ->

--- a/MapboxSearch/ui/src/main/java/com/mapbox/search/ui/view/favorite/rename/EditFavoriteViewController.kt
+++ b/MapboxSearch/ui/src/main/java/com/mapbox/search/ui/view/favorite/rename/EditFavoriteViewController.kt
@@ -26,7 +26,7 @@ internal class EditFavoriteViewController : BaseSearchController {
         favorite = requireNotNull(favoriteBundle.getParcelable(BUNDLE_KEY_FAVORITE))
     }
 
-    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup): View {
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup, savedViewState: Bundle?): View {
         return EditFavoriteView(container.context).apply {
             setFavorite(mode, favorite)
             onCloseClickListener = {

--- a/MapboxSearch/ui/src/main/java/com/mapbox/search/ui/view/feedback/FeedbackReasonViewController.kt
+++ b/MapboxSearch/ui/src/main/java/com/mapbox/search/ui/view/feedback/FeedbackReasonViewController.kt
@@ -15,7 +15,7 @@ internal class FeedbackReasonViewController : Controller {
     // Android Studio marks this constructor as unused, but it's needed for Controller
     constructor(args: Bundle?) : super(args)
 
-    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup): View {
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup, savedViewState: Bundle?): View {
         return FeedbackReasonView(container.context).apply {
             callback = object : FeedbackReasonView.Callback {
                 override fun onBackClick() {

--- a/MapboxSearch/ui/src/main/java/com/mapbox/search/ui/view/feedback/SearchFeedbackViewController.kt
+++ b/MapboxSearch/ui/src/main/java/com/mapbox/search/ui/view/feedback/SearchFeedbackViewController.kt
@@ -25,7 +25,7 @@ internal class SearchFeedbackViewController : BaseSearchController {
         feedbackMode = requireNotNull(bundle.getParcelable(BUNDLE_KEY_FeedbackMode))
     }
 
-    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup): View {
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup, savedViewState: Bundle?): View {
         return SearchFeedbackView(container.context).apply {
             init(feedbackMode)
 

--- a/MapboxSearch/ui/src/main/java/com/mapbox/search/ui/view/main/MainScreenViewController.kt
+++ b/MapboxSearch/ui/src/main/java/com/mapbox/search/ui/view/main/MainScreenViewController.kt
@@ -70,7 +70,7 @@ internal class MainScreenViewController : BaseSearchController {
         searchOptions = requireNotNull(restoreSearchOptionsFromBundle(configBundle))
     }
 
-    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup): View {
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup, savedViewState: Bundle?): View {
         return MainScreenView(container.context).apply {
             id = R.id.main_screen_view
             initializeSearch(configuration)

--- a/MapboxSearch/ui/src/main/java/com/mapbox/search/ui/view/search/address/AddressSearchViewController.kt
+++ b/MapboxSearch/ui/src/main/java/com/mapbox/search/ui/view/search/address/AddressSearchViewController.kt
@@ -51,7 +51,7 @@ internal class AddressSearchViewController : BaseSearchController {
         configuration = requireNotNull(bundle.getParcelable(BUNDLE_KEY_CONFIGURATION))
     }
 
-    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup): View {
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup, savedViewState: Bundle?): View {
         return AddressSearchView(container.context).apply {
             initialize(mode, configuration)
 


### PR DESCRIPTION
<!-- ⚠️ TEMPLATE ⚠️ -->
<!-- Template for GitHub PR descriptions. Use it as a guide on how to describe your work. Feel free to remove any section when you're opening a PR if you think it does not apply for your committed changes. -->

### Description
This PR:
- bumps Condutor library to v3.1.2
- fixes default search options for views
- adds tests for search option limit


### Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have updated the `CHANGELOG` including this PR (where applicable)
- [x] I have run tests and automatic checks locally
- [ ] I have run `pitest` check locally and checked that the coverage increased (or didn't change) or decreased insignificantly
- [x] I have made corresponding changes to the documentation (where applicable)
- [x] I have grouped commits logically or I promise to squash my commits before merge
