### PR TITLE
Rename version name

### DIFF
--- a/MapboxSearch/gradle.properties
+++ b/MapboxSearch/gradle.properties
@@ -21,7 +21,7 @@ android.enableJetifier=false
 kotlin.code.style=official
 
 # SDK version attributes
-versionName=1.0.0-beta.28-SNAPSHOT
+VERSION_NAME=1.0.0-beta.28-SNAPSHOT
 
 # Artifact attributes
 mapboxArtifactUserOrg=mapbox

--- a/MapboxSearch/gradle/publish.gradle
+++ b/MapboxSearch/gradle/publish.gradle
@@ -2,9 +2,9 @@ apply plugin: 'maven-publish'
 apply plugin: 'com.mapbox.sdkRegistry'
 
 project.archivesBaseName = project.property('mapboxArtifactName')
-project.version = project.property('versionName')
+project.version = project.property('VERSION_NAME')
 group = project.property('mapboxArtifactGroup')
-version = project.property('versionName')
+version = project.property('VERSION_NAME')
 
 afterEvaluate {
     publishing {
@@ -14,7 +14,7 @@ afterEvaluate {
 
                 groupId project.property('mapboxArtifactGroup')
                 artifactId project.property('mapboxArtifactName')
-                version project.property('versionName')
+                version project.property('VERSION_NAME')
 
                 artifact(androidSourcesJar)
                 artifact(androidJavadocsJar)
@@ -62,7 +62,7 @@ sdkNameMap["sdk-common"] = "search-sdk-common"
 registry {
     sdkName = sdkNameMap[project.name]
     production = true
-    snapshot = versionName.endsWith("-SNAPSHOT")
+    snapshot = version.endsWith("-SNAPSHOT")
     override = snapshot ? true : false
     dryRun = project.properties['sdkRegistryDryRun'] ?: false
     publications = ["MapboxAndroidSDKPublication"]

--- a/MapboxSearch/sdk-common/build.gradle
+++ b/MapboxSearch/sdk-common/build.gradle
@@ -24,7 +24,7 @@ android {
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
 
-        buildConfigField "String", "VERSION_NAME", "\"$versionName\""
+        buildConfigField "String", "VERSION_NAME", "\"$VERSION_NAME\""
     }
 
     buildTypes {

--- a/scripts/ci-publish-snapshots.sh
+++ b/scripts/ci-publish-snapshots.sh
@@ -2,7 +2,7 @@
 
 set -eo pipefail
 
-VERSION_NAME=`cat MapboxSearch/gradle.properties | grep versionName`
+VERSION_NAME=`cat MapboxSearch/gradle.properties | grep VERSION_NAME`
 if [[ "$VERSION_NAME" == *-SNAPSHOT ]]
   then
     echo "Publishing snapshots to the SDK registry..."

--- a/scripts/ci-validate-release-version.sh
+++ b/scripts/ci-validate-release-version.sh
@@ -2,10 +2,10 @@
 
 set -eo pipefail
 
-DECLARED_VERSION_NAME=`cat MapboxSearch/gradle.properties | grep versionName`
+DECLARED_VERSION_NAME=`cat MapboxSearch/gradle.properties | grep VERSION_NAME`
 
 extract_version_name() {
-  [[ $1 =~ (versionName=)?v?(.*) ]]
+  [[ $1 =~ (VERSION_NAME=)?v?(.*) ]]
   local VERSION=${BASH_REMATCH[2]}
   echo "$VERSION"
 }

--- a/scripts/generate_docs.sh
+++ b/scripts/generate_docs.sh
@@ -4,7 +4,7 @@ set -eo pipefail
 
 pushd MapboxSearch/
 
-searchVersion="$(grep 'versionName' gradle.properties | sed 's/^versionName=//')"
+searchVersion="$(grep 'VERSION_NAME' gradle.properties | sed 's/^VERSION_NAME=//')"
 
 ./gradlew clean
 


### PR DESCRIPTION
This is to drive alignment across Mapbox SDK build systems and allow more easily to build binaries on demand.