### PR TITLE
Pass SearchCancellationException to callbacks when request is cancelled by the Search SDK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Breaking changes
 - [CORE] `OfflineSearchEngine` is a 1-step search now, which means that `SearchResult`'s returned in the first step without `SearchSuggestion` selection. `OfflineSearchEngine.select()` function has been removed. `OfflineSearchEngine.search()` accepts `SearchCallback` callback type.
+- [CORE] Now automatically cancelled by the Search SDK search requests made to the `SearchEngine` and `OfflineSearchEngine` will be passing `SearchCancellationException` to the corresponding callbacks of `SearchCallback`, `SearchSuggestionsCallback`, and `SearchSelectionCallback`.
 - [UI] Now `SearchResultsView.SearchListener` has a new function `onOfflineSearchResults()`.
 
 ### New features

--- a/MapboxSearch/sdk/api/api-metalava.txt
+++ b/MapboxSearch/sdk/api/api-metalava.txt
@@ -674,6 +674,11 @@ package com.mapbox.search {
     method public void onResults(java.util.List<? extends com.mapbox.search.result.SearchResult> results, com.mapbox.search.ResponseInfo responseInfo);
   }
 
+  public final class SearchCancellationException extends java.lang.RuntimeException {
+    ctor public SearchCancellationException(String message);
+    property public String message;
+  }
+
   public interface SearchEngine {
     method public com.mapbox.search.ApiType getApiType();
     method public <R extends com.mapbox.search.record.IndexableRecord> com.mapbox.search.AsyncOperationTask registerDataProvider(com.mapbox.search.record.IndexableDataProvider<R> dataProvider, java.util.concurrent.Executor executor, com.mapbox.search.CompletionCallback<kotlin.Unit> callback);

--- a/MapboxSearch/sdk/api/sdk.api
+++ b/MapboxSearch/sdk/api/sdk.api
@@ -733,6 +733,14 @@ public abstract interface class com/mapbox/search/SearchCallback {
 	public abstract fun onResults (Ljava/util/List;Lcom/mapbox/search/ResponseInfo;)V
 }
 
+public final class com/mapbox/search/SearchCancellationException : java/lang/RuntimeException {
+	public fun <init> (Ljava/lang/String;)V
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getMessage ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
 public abstract interface class com/mapbox/search/SearchEngine {
 	public abstract fun getApiType ()Lcom/mapbox/search/ApiType;
 	public abstract fun registerDataProvider (Lcom/mapbox/search/record/IndexableDataProvider;Lcom/mapbox/search/CompletionCallback;)Lcom/mapbox/search/AsyncOperationTask;

--- a/MapboxSearch/sdk/src/main/java/com/mapbox/search/OfflineSearchEngine.kt
+++ b/MapboxSearch/sdk/src/main/java/com/mapbox/search/OfflineSearchEngine.kt
@@ -3,7 +3,6 @@ package com.mapbox.search
 import com.mapbox.common.TileStore
 import com.mapbox.common.TilesetDescriptor
 import com.mapbox.geojson.Point
-import com.mapbox.search.result.SearchSuggestion
 import com.mapbox.search.utils.concurrent.SearchSdkMainThreadWorker
 import java.util.concurrent.Executor
 
@@ -119,7 +118,9 @@ public interface OfflineSearchEngine {
     )
 
     /**
-     * The first step of the offline forward geocoding. Returns a list of [SearchSuggestion] without coordinates.
+     * Performs forward geocoding search request.
+     * Each new search request cancels the previous one if it is still in progress.
+     * In this case [SearchCallback.onError] will be called with [SearchCancellationException].
      *
      * @param query Search query.
      * @param options Search options.
@@ -137,7 +138,9 @@ public interface OfflineSearchEngine {
     ): SearchRequestTask
 
     /**
-     * The first step of the offline forward geocoding. Returns a list of [SearchSuggestion] without coordinates.
+     * Performs forward geocoding search request.
+     * Each new search request cancels the previous one if it is still in progress.
+     * In this case [SearchCallback.onError] will be called with [SearchCancellationException].
      *
      * @param query Search query.
      * @param options Search options.
@@ -158,7 +161,9 @@ public interface OfflineSearchEngine {
     )
 
     /**
-     * Performs reverse geocoding.
+     * Performs reverse geocoding search request.
+     * Each new search request cancels the previous one if it is still in progress.
+     * In this case [SearchCallback.onError] will be called with [SearchCancellationException].
      *
      * @param options Reverse geocoding options.
      * @param executor Executor used for events dispatching. By default events are dispatched on the main thread.
@@ -172,7 +177,9 @@ public interface OfflineSearchEngine {
     ): SearchRequestTask
 
     /**
-     * Performs reverse geocoding.
+     * Performs reverse geocoding search request.
+     * Each new search request cancels the previous one if it is still in progress.
+     * In this case [SearchCallback.onError] will be called with [SearchCancellationException].
      *
      * @param options Reverse geocoding options.
      * @param callback Search result callback, delivers results on the main thread.
@@ -189,6 +196,8 @@ public interface OfflineSearchEngine {
 
     /**
      * Searches for addresses nearby (around [proximity] point), matched with specified [street] name.
+     * Each new search request cancels the previous one if it is still in progress.
+     * In this case [SearchCallback.onError] will be called with [SearchCancellationException].
      *
      * @param street Street name to match.
      * @param proximity Coordinate to search in its vicinity.
@@ -207,6 +216,8 @@ public interface OfflineSearchEngine {
 
     /**
      * Searches for addresses nearby (around [proximity] point), matched with specified [street] name.
+     * Each new search request cancels the previous one if it is still in progress.
+     * In this case [SearchCallback.onError] will be called with [SearchCancellationException].
      *
      * @param street Street name to match.
      * @param proximity Coordinate to search in its vicinity.

--- a/MapboxSearch/sdk/src/main/java/com/mapbox/search/OfflineSearchEngineImpl.kt
+++ b/MapboxSearch/sdk/src/main/java/com/mapbox/search/OfflineSearchEngineImpl.kt
@@ -23,7 +23,7 @@ internal class OfflineSearchEngineImpl(
     private val searchResultFactory: SearchResultFactory,
     private val engineExecutorService: ExecutorService,
     override val tileStore: TileStore,
-) : BaseSearchEngine(autoCancelPreviousRequest = true), OfflineSearchEngine {
+) : BaseSearchEngine(), OfflineSearchEngine {
 
     private val initializationLock = Any()
     private val engineReadyCallbacks = mutableMapOf<EngineReadyCallback, Executor>()

--- a/MapboxSearch/sdk/src/main/java/com/mapbox/search/SearchCancellationException.kt
+++ b/MapboxSearch/sdk/src/main/java/com/mapbox/search/SearchCancellationException.kt
@@ -1,0 +1,39 @@
+package com.mapbox.search
+
+import java.lang.RuntimeException
+
+/**
+ * Exception thrown when a search request was automatically cancelled by the Search SDK.
+ * @property [message] cancellation reason.
+ */
+public class SearchCancellationException(
+    override val message: String
+) : RuntimeException(message) {
+
+    /**
+     * @suppress
+     */
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as SearchCancellationException
+
+        if (message != other.message) return false
+        return true
+    }
+
+    /**
+     * @suppress
+     */
+    override fun hashCode(): Int {
+        return message.hashCode()
+    }
+
+    /**
+     * @suppress
+     */
+    override fun toString(): String {
+        return "SearchCancellationException(message='$message')"
+    }
+}

--- a/MapboxSearch/sdk/src/main/java/com/mapbox/search/engine/BaseSearchEngine.kt
+++ b/MapboxSearch/sdk/src/main/java/com/mapbox/search/engine/BaseSearchEngine.kt
@@ -3,16 +3,8 @@ package com.mapbox.search.engine
 import com.mapbox.search.SearchRequestTask
 import com.mapbox.search.SearchRequestTaskImpl
 import com.mapbox.search.plusAssign
-import java.lang.ref.WeakReference
 
-internal abstract class BaseSearchEngine(
-    /**
-     * TODO Temporary solution for https://github.com/mapbox/mapbox-search-sdk/issues/830
-     */
-    private val autoCancelPreviousRequest: Boolean = false
-) {
-
-    private var previousRequestTask: WeakReference<SearchRequestTask>? = null
+internal abstract class BaseSearchEngine {
 
     protected fun <T> makeRequest(
         callback: T,
@@ -21,13 +13,7 @@ internal abstract class BaseSearchEngine(
         val task = SearchRequestTaskImpl<T>().apply {
             callbackDelegate = callback
         }
-
         searchCall(task)
-        if (autoCancelPreviousRequest) {
-            previousRequestTask?.get()?.cancel()
-            previousRequestTask = WeakReference(task)
-        }
-
         return task
     }
 }

--- a/MapboxSearch/sdk/src/main/java/com/mapbox/search/engine/OneStepRequestCallbackWrapper.kt
+++ b/MapboxSearch/sdk/src/main/java/com/mapbox/search/engine/OneStepRequestCallbackWrapper.kt
@@ -4,6 +4,7 @@ import androidx.collection.SparseArrayCompat
 import com.mapbox.search.AsyncOperationTask
 import com.mapbox.search.ResponseInfo
 import com.mapbox.search.SearchCallback
+import com.mapbox.search.SearchCancellationException
 import com.mapbox.search.SearchRequestTaskImpl
 import com.mapbox.search.common.reportRelease
 import com.mapbox.search.common.throwDebug
@@ -11,6 +12,7 @@ import com.mapbox.search.core.CoreSearchCallback
 import com.mapbox.search.core.CoreSearchResponse
 import com.mapbox.search.core.CoreSearchResponseErrorType
 import com.mapbox.search.mapToPlatform
+import com.mapbox.search.markCancelledAndRunOnCallback
 import com.mapbox.search.markExecutedAndRunOnCallback
 import com.mapbox.search.plusAssign
 import com.mapbox.search.result.SearchRequestContext
@@ -79,7 +81,9 @@ internal class OneStepRequestCallbackWrapper(
                             }
                         }
                         CoreSearchResponseErrorType.REQUEST_CANCELLED -> {
-                            searchRequestTask.cancel()
+                            searchRequestTask.markCancelledAndRunOnCallback(callbackExecutor) {
+                                onError(SearchCancellationException(coreError.requestCancelled.reason))
+                            }
                         }
                         null -> {
                             val error = IllegalStateException("CoreSearchResponse.error.typeInfo is null")

--- a/MapboxSearch/sdk/src/main/java/com/mapbox/search/engine/TwoStepsBatchRequestCallbackWrapper.kt
+++ b/MapboxSearch/sdk/src/main/java/com/mapbox/search/engine/TwoStepsBatchRequestCallbackWrapper.kt
@@ -1,6 +1,7 @@
 package com.mapbox.search.engine
 
 import com.mapbox.search.ResponseInfo
+import com.mapbox.search.SearchCancellationException
 import com.mapbox.search.SearchMultipleSelectionCallback
 import com.mapbox.search.SearchRequestTaskImpl
 import com.mapbox.search.common.assertDebug
@@ -9,6 +10,7 @@ import com.mapbox.search.core.CoreSearchCallback
 import com.mapbox.search.core.CoreSearchResponse
 import com.mapbox.search.core.CoreSearchResponseErrorType
 import com.mapbox.search.mapToPlatform
+import com.mapbox.search.markCancelledAndRunOnCallback
 import com.mapbox.search.markExecutedAndRunOnCallback
 import com.mapbox.search.result.SearchRequestContext
 import com.mapbox.search.result.SearchResult
@@ -76,7 +78,9 @@ internal class TwoStepsBatchRequestCallbackWrapper(
                             }
                         }
                         CoreSearchResponseErrorType.REQUEST_CANCELLED -> {
-                            searchRequestTask.cancel()
+                            searchRequestTask.markCancelledAndRunOnCallback(callbackExecutor) {
+                                onError(SearchCancellationException(coreError.requestCancelled.reason))
+                            }
                         }
                         null -> {
                             val error = IllegalStateException("CoreSearchResponse.error.typeInfo is null")

--- a/MapboxSearch/sdk/src/main/java/com/mapbox/search/engine/TwoStepsRequestCallbackWrapper.kt
+++ b/MapboxSearch/sdk/src/main/java/com/mapbox/search/engine/TwoStepsRequestCallbackWrapper.kt
@@ -6,6 +6,7 @@ import com.mapbox.search.AsyncOperationTask
 import com.mapbox.search.CompletionCallback
 import com.mapbox.search.RequestOptions
 import com.mapbox.search.ResponseInfo
+import com.mapbox.search.SearchCancellationException
 import com.mapbox.search.SearchRequestTaskImpl
 import com.mapbox.search.SearchSelectionCallback
 import com.mapbox.search.SearchSuggestionsCallback
@@ -18,6 +19,7 @@ import com.mapbox.search.core.CoreSearchEngineInterface
 import com.mapbox.search.core.CoreSearchResponse
 import com.mapbox.search.core.CoreSearchResponseErrorType
 import com.mapbox.search.mapToPlatform
+import com.mapbox.search.markCancelledAndRunOnCallback
 import com.mapbox.search.markExecutedAndRunOnCallback
 import com.mapbox.search.plusAssign
 import com.mapbox.search.record.HistoryService
@@ -94,7 +96,9 @@ internal class TwoStepsRequestCallbackWrapper(
                             }
                         }
                         CoreSearchResponseErrorType.REQUEST_CANCELLED -> {
-                            searchRequestTask.cancel()
+                            searchRequestTask.markCancelledAndRunOnCallback(callbackExecutor) {
+                                onError(SearchCancellationException(coreError.requestCancelled.reason))
+                            }
                         }
                         null -> {
                             val error = IllegalStateException("CoreSearchResponse.error.typeInfo is null")

--- a/MapboxSearch/sdk/src/test/java/com/mapbox/search/CategorySearchTest.kt
+++ b/MapboxSearch/sdk/src/test/java/com/mapbox/search/CategorySearchTest.kt
@@ -216,68 +216,33 @@ internal class CategorySearchTest {
     }
 
     @TestFactory
-    fun `Check consecutive search calls`() = TestCase {
-        Given("GeocodingSearchEngine with mocked dependencies") {
+    fun `Check search call cancellation`() = TestCase {
+        Given("SearchEngine with mocked dependencies") {
             every { searchResultFactory.createSearchResult(any(), any()) } returns TEST_SEARCH_RESULT
 
-            val options = CategorySearchOptions()
+            val cancellationReason = "Request cancelled"
 
-            val category1 = "cafe"
-            val slotSearchCallback1 = slot<CoreSearchCallback>()
-            every { coreEngine.search(eq(""), eq(listOf(category1)), any(), capture(slotSearchCallback1)) } returns Unit
-
-            val category2 = "museum"
-            val slotSearchCallback2 = slot<CoreSearchCallback>()
-            every { coreEngine.search(eq(""), eq(listOf(category2)), any(), capture(slotSearchCallback2)) } returns Unit
-
-            var searchRequestTask1: SearchRequestTaskImpl<*>? = null
-            When("Search function called for the first time") {
-                val callback1 = mockk<SearchCallback>(relaxed = true)
-                searchRequestTask1 = (searchEngine.search(category1, options, callback1) as? SearchRequestTaskImpl<*>)
-
-                Then("First task is not executed", false, searchRequestTask1?.isDone)
-                Then("First task is not cancelled", false, searchRequestTask1?.isCancelled)
-                Then(
-                    "First task keeps original listener",
-                    true,
-                    searchRequestTask1?.callbackDelegate != null
-                )
+            val slotSearchCallback = slot<CoreSearchCallback>()
+            every { coreEngine.search(eq(""), eq(listOf(TEST_CATEGORIES_QUERY)), any(), capture(slotSearchCallback)) } answers {
+                slotSearchCallback.captured.run(createTestCoreSearchResponseCancelled(cancellationReason))
             }
 
-            var searchRequestTask2: SearchRequestTaskImpl<*>? = null
-            When("Search function called for the second time and first request automatically cancelled") {
-                slotSearchCallback1.captured.run(createTestCoreSearchResponseCancelled())
+            When("Search request cancelled by the Search SDK") {
+                val callback = mockk<SearchCallback>(relaxed = true)
 
-                val callback2 = mockk<SearchCallback>(relaxed = true)
-                searchRequestTask2 = (searchEngine.search(category2, options, callback2) as? SearchRequestTaskImpl<*>)
+                val task = (searchEngine.search(TEST_CATEGORIES_QUERY, TEST_SEARCH_OPTIONS, callback) as? SearchRequestTaskImpl<*>)
 
-                Then("First task is not executed", false, searchRequestTask1?.isDone)
-                Then("First task is cancelled", true, searchRequestTask1?.isCancelled)
+                Then("Task is not executed", false, task?.isDone)
+                Then("Task is cancelled", true, task?.isCancelled)
                 Then(
-                    "First task still keeps reference to original listener",
-                    false,
-                    searchRequestTask1?.callbackDelegate != null
-                )
-
-                Then("Second task is not executed", false, searchRequestTask2?.isDone)
-                Then("Second task is not cancelled", false, searchRequestTask2?.isCancelled)
-                Then(
-                    "Second task keeps original listener",
+                    "Task released reference to original callback",
                     true,
-                    searchRequestTask2?.callbackDelegate != null
+                    task?.callbackDelegate == null
                 )
-            }
 
-            When("Second search request completes") {
-                slotSearchCallback2.captured.run(TEST_SUCCESSFUL_CORE_RESPONSE)
-
-                Then("Second task is executed", true, searchRequestTask2?.isDone)
-                Then("Second task is not cancelled", false, searchRequestTask2?.isCancelled)
-                Then(
-                    "Second task released reference to original listener",
-                    true,
-                    searchRequestTask2?.callbackDelegate == null
-                )
+                VerifyOnce("Callback called with cancellation error") {
+                    callback.onError(eq(SearchCancellationException(cancellationReason)))
+                }
             }
         }
     }

--- a/MapboxSearch/sdk/src/test/java/com/mapbox/search/SearchEngineTest.kt
+++ b/MapboxSearch/sdk/src/test/java/com/mapbox/search/SearchEngineTest.kt
@@ -232,68 +232,31 @@ internal class SearchEngineTest {
     }
 
     @TestFactory
-    fun `Check consecutive search calls`() = TestCase {
+    fun `Check search call cancellation`() = TestCase {
         Given("SearchEngine with mocked dependencies") {
-            val searchQuery1 = "Query 1"
-            val slotSearchCallback1 = slot<CoreSearchCallback>()
-            every { coreEngine.search(eq(searchQuery1), any(), any(), capture(slotSearchCallback1)) } returns Unit
+            val cancellationReason = "Request cancelled"
 
-            val searchQuery2 = "Query 2"
-            val slotSearchCallback2 = slot<CoreSearchCallback>()
-            every { coreEngine.search(eq(searchQuery2), any(), any(), capture(slotSearchCallback2)) } returns Unit
-
-            var searchRequestTask1: SearchRequestTaskImpl<*>? = null
-            When("Search function called for the first time") {
-                val callback1 = mockk<SearchSuggestionsCallback>(relaxed = true)
-
-                searchRequestTask1 =
-                    (searchEngine.search(searchQuery1, TEST_SEARCH_OPTIONS, callback1) as? SearchRequestTaskImpl<*>)
-
-                Then("First task is not executed", false, searchRequestTask1?.isDone)
-                Then("First task is not cancelled", false, searchRequestTask1?.isCancelled)
-                Then(
-                    "First task keeps original callback",
-                    true,
-                    searchRequestTask1?.callbackDelegate != null
-                )
+            val slotSearchCallback = slot<CoreSearchCallback>()
+            every { coreEngine.search(eq(TEST_QUERY), any(), any(), capture(slotSearchCallback)) } answers {
+                slotSearchCallback.captured.run(createTestCoreSearchResponseCancelled(cancellationReason))
             }
 
-            var searchRequestTask2: SearchRequestTaskImpl<*>? = null
-            When("Search function called for the second time and first request automatically cancelled") {
-                slotSearchCallback1.captured.run(createTestCoreSearchResponseCancelled())
+            When("Search request cancelled by the Search SDK") {
+                val callback = mockk<SearchSuggestionsCallback>(relaxed = true)
 
-                val callback2 = mockk<SearchSuggestionsCallback>(relaxed = true)
+                val task = (searchEngine.search(TEST_QUERY, TEST_SEARCH_OPTIONS, callback) as? SearchRequestTaskImpl<*>)
 
-                searchRequestTask2 =
-                    (searchEngine.search(searchQuery2, TEST_SEARCH_OPTIONS, callback2) as? SearchRequestTaskImpl<*>)
-
-                Then("First task is not executed", false, searchRequestTask1?.isDone)
-                Then("First task is cancelled", true, searchRequestTask1?.isCancelled)
+                Then("Task is not executed", false, task?.isDone)
+                Then("Task is cancelled", true, task?.isCancelled)
                 Then(
-                    "First task released reference to original callback",
+                    "Task released reference to original callback",
                     true,
-                    searchRequestTask1?.callbackDelegate == null
+                    task?.callbackDelegate == null
                 )
 
-                Then("Second task is not executed", false, searchRequestTask2?.isDone)
-                Then("Second task is not cancelled", false, searchRequestTask2?.isCancelled)
-                Then(
-                    "Second task keeps original callback",
-                    true,
-                    searchRequestTask2?.callbackDelegate != null
-                )
-            }
-
-            When("Second search request completes") {
-                slotSearchCallback2.captured.run(TEST_SUCCESSFUL_CORE_RESPONSE)
-
-                Then("Second task is executed", true, searchRequestTask2?.isDone)
-                Then("Second task is not cancelled", false, searchRequestTask2?.isCancelled)
-                Then(
-                    "Second task released reference to original callback",
-                    true,
-                    searchRequestTask2?.callbackDelegate == null
-                )
+                VerifyOnce("Callback called with cancellation error") {
+                    callback.onError(eq(SearchCancellationException(cancellationReason)))
+                }
             }
         }
     }


### PR DESCRIPTION
### Description
Now automatically cancelled by the Search SDK search requests made to the `SearchEngine` and `OfflineSearchEngine` will be passing `SearchCancellationException` to the corresponding callbacks of `SearchCallback`, `SearchSuggestionsCallback`, and `SearchSelectionCallback`.

Closes https://github.com/mapbox/mapbox-search-android-internal/issues/795



### Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have updated the `CHANGELOG` including this PR (where applicable)
- [x] I have run tests and automatic checks locally
- [ ] I have run `pitest` check locally and checked that the coverage increased (or didn't change) or decreased insignificantly
- [x] I have made corresponding changes to the documentation (where applicable)
- [x] I have grouped commits logically or I promise to squash my commits before merge
