### PR TITLE
New fields; Bug fix; `1.0.0-beta.33.1` release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog for the Mapbox Search SDK for Android
 
-## 1.0.0-beta.34-SNAPSHOT
+## 1.0.0-beta.33.1
+
+### New features
+- [CORE] Now `RequestOptions` provides new fields `endpoint` and `sessionID`.
+
+### Bug fixes
+- [CORE] Now `SearchAddress.formattedAddress(FormatStyle.Medium)` for address with country `United States` includes region.
 
 ### Mapbox dependencies
 - Search Native SDK `0.57.0`

--- a/MapboxSearch/gradle.properties
+++ b/MapboxSearch/gradle.properties
@@ -21,7 +21,7 @@ android.enableJetifier=false
 kotlin.code.style=official
 
 # SDK version attributes
-VERSION_NAME=1.0.0-beta.34-SNAPSHOT
+VERSION_NAME=1.0.0-beta.33.1-SNAPSHOT
 
 # Artifact attributes
 mapboxArtifactUserOrg=mapbox

--- a/MapboxSearch/sdk/api/api-metalava.txt
+++ b/MapboxSearch/sdk/api/api-metalava.txt
@@ -587,14 +587,18 @@ package com.mapbox.search {
   }
 
   @kotlinx.parcelize.Parcelize public final class RequestOptions implements android.os.Parcelable {
+    method public String getEndpoint();
     method public com.mapbox.search.SearchOptions getOptions();
     method public boolean getOriginRewritten();
     method public boolean getProximityRewritten();
     method public String getQuery();
+    method public String getSessionID();
+    property public final String endpoint;
     property public final com.mapbox.search.SearchOptions options;
     property public final boolean originRewritten;
     property public final boolean proximityRewritten;
     property public final String query;
+    property public final String sessionID;
   }
 
   public final class RequestOptionsKt {

--- a/MapboxSearch/sdk/api/sdk.api
+++ b/MapboxSearch/sdk/api/sdk.api
@@ -621,10 +621,12 @@ public final class com/mapbox/search/RequestOptions : android/os/Parcelable {
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
+	public final fun getEndpoint ()Ljava/lang/String;
 	public final fun getOptions ()Lcom/mapbox/search/SearchOptions;
 	public final fun getOriginRewritten ()Z
 	public final fun getProximityRewritten ()Z
 	public final fun getQuery ()Ljava/lang/String;
+	public final fun getSessionID ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 	public fun writeToParcel (Landroid/os/Parcel;I)V

--- a/MapboxSearch/sdk/src/main/java/com/mapbox/search/RequestOptions.kt
+++ b/MapboxSearch/sdk/src/main/java/com/mapbox/search/RequestOptions.kt
@@ -18,6 +18,10 @@ import kotlinx.parcelize.Parcelize
  *
  * @property originRewritten denotes whether [SearchOptions.origin] property has been rewritten by the Search SDK.
  * This may happen when passed to the [com.mapbox.search.SearchEngine] [SearchOptions] don't have [SearchOptions.origin] set.
+ *
+ * @property endpoint Search method. One of { "suggest", "category", "reverse" }.
+ *
+ * @property sessionID Session ID that groups a series of requests for billing purposes.
  */
 @Parcelize
 public class RequestOptions internal constructor(
@@ -25,8 +29,8 @@ public class RequestOptions internal constructor(
     public val options: SearchOptions,
     public val proximityRewritten: Boolean,
     public val originRewritten: Boolean,
-    @get:JvmSynthetic internal val endpoint: String,
-    @get:JvmSynthetic internal val sessionID: String,
+    public val endpoint: String,
+    public val sessionID: String,
     @get:JvmSynthetic internal val requestContext: SearchRequestContext,
 ) : Parcelable {
 

--- a/MapboxSearch/sdk/src/main/java/com/mapbox/search/result/SearchAddress.kt
+++ b/MapboxSearch/sdk/src/main/java/com/mapbox/search/result/SearchAddress.kt
@@ -191,7 +191,7 @@ public class SearchAddress @JvmOverloads public constructor(
     }
 
     private fun isCountryWithRegions(country: String?): Boolean = country?.let {
-        listOf("united states of america", "usa").contains(country.lowercase(Locale.getDefault()))
+        listOf("united states of america", "united states", "usa").contains(country.lowercase(Locale.getDefault()))
     } ?: false
 
     /**

--- a/MapboxSearch/sdk/src/test/java/com/mapbox/search/result/SearchAddressTest.kt
+++ b/MapboxSearch/sdk/src/test/java/com/mapbox/search/result/SearchAddressTest.kt
@@ -34,13 +34,15 @@ internal class SearchAddressTest {
     }
 
     @TestFactory
-    fun `Check formattedAddress for region address`() = TestCase {
+    fun `Check formattedAddress for country with regions`() = TestCase {
         Given("Full SearchAddresses") {
-            val address = REGION_SEARCH_ADDRESS
-            When("Call default formattedAddress for region $address") {
-                val actualValue = address.formattedAddress()
-                val expectedValue = "$HOUSE_NUMBER $STREET, $PLACE, $REGION"
-                Then("It should be <$expectedValue>", expectedValue, actualValue)
+            listOf("united states of america", "united states", "usa").forEach { country ->
+                val address = FULL_SEARCH_ADDRESS.copy(country = country)
+                When("Call default formattedAddress for country = $country") {
+                    val actualValue = address.formattedAddress()
+                    val expectedValue = "$HOUSE_NUMBER $STREET, $PLACE, $REGION"
+                    Then("It should be <$expectedValue>", expectedValue, actualValue)
+                }
             }
         }
     }
@@ -55,8 +57,8 @@ internal class SearchAddressTest {
                 SearchAddress.FormatStyle.Long to "$HOUSE_NUMBER $STREET, $NEIGHBORHOOD, $LOCALITY, $PLACE, $DISTRICT, $REGION, $COUNTRY",
                 SearchAddress.FormatStyle.Full to "$HOUSE_NUMBER $STREET, $NEIGHBORHOOD, $LOCALITY, $PLACE, $DISTRICT, $REGION, $COUNTRY, $POSTCODE",
 
-                SearchAddress.FormatStyle.Custom(SearchAddress.FormatComponent.HOUSE_NUMBER) to "$HOUSE_NUMBER",
-                SearchAddress.FormatStyle.Custom(SearchAddress.FormatComponent.REGION) to "$REGION",
+                SearchAddress.FormatStyle.Custom(SearchAddress.FormatComponent.HOUSE_NUMBER) to HOUSE_NUMBER,
+                SearchAddress.FormatStyle.Custom(SearchAddress.FormatComponent.REGION) to REGION,
 
                 SearchAddress.FormatStyle.Custom(
                     SearchAddress.FormatComponent.HOUSE_NUMBER,
@@ -102,8 +104,7 @@ internal class SearchAddressTest {
         const val COUNTRY = "country"
 
         val EMPTY_SEARCH_ADDRESS = SearchAddress("", "", "", "", "", "", "", "", "")
-        val NULL_SEARCH_ADDRESS =
-            SearchAddress(null, null, null, null, null, null, null, null, null)
+        val NULL_SEARCH_ADDRESS = SearchAddress(null, null, null, null, null, null, null, null, null)
         val FULL_SEARCH_ADDRESS = SearchAddress(
             HOUSE_NUMBER,
             STREET,
@@ -115,9 +116,5 @@ internal class SearchAddressTest {
             REGION,
             COUNTRY
         )
-
-        val REGION_SEARCH_ADDRESS = FULL_SEARCH_ADDRESS.toBuilder()
-            .country(country = "USA")
-            .build()
     }
 }


### PR DESCRIPTION
<!-- ⚠️ TEMPLATE ⚠️ -->
<!-- Template for GitHub PR descriptions. Use it as a guide on how to describe your work. Feel free to remove any section when you're opening a PR if you think it does not apply for your committed changes. -->

### Description
This PR:
- Adds region in formatted address for United States. Closes https://github.com/mapbox/mapbox-search-android/issues/60
- Exposes  new fields `endpoint` and `sessionID` for `RequestOptions`
- Bumps SDK version to 1.0.0-beta.33.1



### Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have updated the `CHANGELOG` including this PR (where applicable)
- [ ] I have run tests and automatic checks locally
- [ ] I have run `pitest` check locally and checked that the coverage increased (or didn't change) or decreased insignificantly
- [x] I have made corresponding changes to the documentation (where applicable)
- [x] I have grouped commits logically or I promise to squash my commits before merge
