### PR TITLE
Bump Search SDK version to 1.0.0-beta.36-SNAPSHOT; Fix api references publishing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 1.0.0-beta.36-SNAPSHOT
 
+### Bug fixes
+- [UI] Now created in the `SearchPlaceBottomSheetView` `FavoriteRecord` will be saved with id from `SearchPlace.id`
+
 ### Mapbox dependencies
 - Search Native SDK `0.58.0`
 - Common SDK `23.0.0-beta.1`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog for the Mapbox Search SDK for Android
 
+## 1.0.0-beta.36-SNAPSHOT
+
+### Mapbox dependencies
+- Search Native SDK `0.58.0`
+- Common SDK `23.0.0-beta.1`
+- Kotlin `1.5.31`
+
+
+
 ## 1.0.0-beta.35
 
 ### Breaking changes

--- a/MapboxSearch/gradle.properties
+++ b/MapboxSearch/gradle.properties
@@ -21,7 +21,7 @@ android.enableJetifier=false
 kotlin.code.style=official
 
 # SDK version attributes
-VERSION_NAME=1.0.0-beta.35
+VERSION_NAME=1.0.0-beta.36-SNAPSHOT
 
 # Artifact attributes
 mapboxArtifactUserOrg=mapbox

--- a/MapboxSearch/ui/src/main/java/com/mapbox/search/ui/view/place/SearchPlaceBottomSheetView.kt
+++ b/MapboxSearch/ui/src/main/java/com/mapbox/search/ui/view/place/SearchPlaceBottomSheetView.kt
@@ -29,7 +29,6 @@ import com.mapbox.search.ui.view.CommonSearchViewConfiguration
 import com.mapbox.search.ui.view.SearchSdkFrameLayout
 import com.mapbox.search.ui.view.common.MapboxSdkButtonWithIcon
 import kotlinx.parcelize.Parcelize
-import java.util.UUID
 import java.util.concurrent.CopyOnWriteArrayList
 import kotlin.annotation.AnnotationRetention.SOURCE
 
@@ -603,7 +602,7 @@ public class SearchPlaceBottomSheetView @JvmOverloads constructor(
                 record
             } else {
                 FavoriteRecord(
-                    id = UUID.randomUUID().toString(),
+                    id = id,
                     name = name,
                     coordinate = coordinate,
                     descriptionText = descriptionText,

--- a/scripts/ci-publish-api-reference.sh
+++ b/scripts/ci-publish-api-reference.sh
@@ -33,8 +33,13 @@ git checkout "$BRANCH_NAME"
 #
 # Copy API reference
 #
+mkdir -p "${TMPDIR}/core"
 cp -r "${INITIAL_PATH}/MapboxSearch/sdk/build/dokka" "${TMPDIR}/core/${VERSION}"
+
+mkdir -p "${TMPDIR}/ui"
 cp -r "${INITIAL_PATH}/MapboxSearch/ui/build/dokka" "${TMPDIR}/ui/${VERSION}"
+
+mkdir -p "${TMPDIR}/autofill"
 cp -r "${INITIAL_PATH}/MapboxSearch/autofill/build/dokka" "${TMPDIR}/autofill/${VERSION}"
 
 git config user.email "release-bot@mapbox.com"


### PR DESCRIPTION
<!-- ⚠️ TEMPLATE ⚠️ -->
<!-- Template for GitHub PR descriptions. Use it as a guide on how to describe your work. Feel free to remove any section when you're opening a PR if you think it does not apply for your committed changes. -->

### Description
This PR:
- Bumps Search SDK version to `1.0.0-beta.36-SNAPSHOT`
- Fixes API references uploading
- Uses passed `SearchPlace.id` as a saved favorite id.


### Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have updated the `CHANGELOG` including this PR (where applicable)
- [x] I have run tests and automatic checks locally
- [ ] I have run `pitest` check locally and checked that the coverage increased (or didn't change) or decreased insignificantly
- [x] I have made corresponding changes to the documentation (where applicable)
- [x] I have grouped commits logically or I promise to squash my commits before merge
