### PR TITLE
Search SDK release with common SDK 23

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog for the Mapbox Search SDK for Android
 
-## 1.0.0-beta.36-SNAPSHOT
+## 1.0.0-beta.36
 
 ### Breaking changes
 - [CORE] `AsyncOperationTask`, `SearchCancellationException`, `SearchRequestException`, `RoutablePoint` have been moved to `com.mapbox.search.common` package. `MainThreadWorker`, and `SearchSdkMainThreadWorker` have been moved to `com.mapbox.search.common.concurrent`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,8 +17,8 @@
 - [UI] Now created in the `SearchPlaceBottomSheetView` `FavoriteRecord` will be saved with id from `SearchPlace.id`
 
 ### Mapbox dependencies
-- Search Native SDK `0.58.0`
-- Common SDK `23.0.0-beta.1`
+- Search Native SDK `0.59.0`
+- Common SDK `23.0.0`
 - Kotlin `1.5.31`
 
 

--- a/MapboxSearch/gradle.properties
+++ b/MapboxSearch/gradle.properties
@@ -21,7 +21,7 @@ android.enableJetifier=false
 kotlin.code.style=official
 
 # SDK version attributes
-VERSION_NAME=1.0.0-beta.36-SNAPSHOT
+VERSION_NAME=1.0.0-beta.36
 
 # Artifact attributes
 mapboxArtifactUserOrg=mapbox

--- a/MapboxSearch/gradle/versions.gradle
+++ b/MapboxSearch/gradle/versions.gradle
@@ -41,12 +41,12 @@ ext {
 
     pitest_version = '1.6.7'
 
-    mapbox_maps_version = '10.8.0-beta.1'
-    common_sdk_version = '23.0.0-beta.1'
+    mapbox_maps_version = '10.8.0'
+    common_sdk_version = '23.0.0'
     mapbox_base_version = '0.8.0'
     mapbox_android_core_version = '5.0.2'
 
-    search_native_version = '0.58.0'
+    search_native_version = '0.59.0'
 
     detekt_version = '1.19.0'
 


### PR DESCRIPTION
<!-- ⚠️ TEMPLATE ⚠️ -->
<!-- Template for GitHub PR descriptions. Use it as a guide on how to describe your work. Feel free to remove any section when you're opening a PR if you think it does not apply for your committed changes. -->

### Description
This PR
- bumps Native Search SDK to `0.59.0`
- bumps Common SDK to `23.0.0`
- Bums Search SDK version to `1.0.0-beta.36`

### Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR (where applicable)
- [ ] I have run tests and automatic checks locally
- [ ] I have run `pitest` check locally and checked that the coverage increased (or didn't change) or decreased insignificantly
- [ ] I have made corresponding changes to the documentation (where applicable)
- [ ] I have grouped commits logically or I promise to squash my commits before merge
