### PR TITLE
Bump SDK version to 1.0.0-beta.38-SNAPSHOT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog for the Mapbox Search SDK for Android
 
+## 1.0.0-beta.38-SNAPSHOT
+
+### Mapbox dependencies
+- Search Native SDK `0.60.0`
+- Common SDK `23.1.0-beta.1`
+- Kotlin `1.5.31`
+
+
+
 ## 1.0.0-beta.37
 
 ### Breaking changes

--- a/MapboxSearch/gradle.properties
+++ b/MapboxSearch/gradle.properties
@@ -21,7 +21,7 @@ android.enableJetifier=false
 kotlin.code.style=official
 
 # SDK version attributes
-VERSION_NAME=1.0.0-beta.37
+VERSION_NAME=1.0.0-beta.38-SNAPSHOT
 
 # Artifact attributes
 mapboxArtifactUserOrg=mapbox


### PR DESCRIPTION
### Description
This PR bumps SDK version to `1.0.0-beta.38-SNAPSHOT`


### Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have updated the `CHANGELOG` including this PR (where applicable)
- [x] I have run tests and automatic checks locally
- [ ] I have run `pitest` check locally and checked that the coverage increased (or didn't change) or decreased insignificantly
- [x] I have made corresponding changes to the documentation (where applicable)
- [x] I have grouped commits logically or I promise to squash my commits before merge
