### PR TITLE
UI bug fix; 1.0.0-beta.38.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog for the Mapbox Search SDK for Android
 
+## 1.0.0-beta.38.1
+
+### Bug fixes
+- [UI] Fixed a bug in `SearchEngineUiAdapter` where `SearchListener.onPopulateQueryClick()` was not called when user clicked the `query populate` button.
+
+### Mapbox dependencies
+- Search Native SDK `0.61.0`
+- Common SDK `23.1.0-rc.1`
+- Kotlin `1.5.31`
+
+
+
 ## 1.0.0-beta.38
 
 ### Breaking changes

--- a/MapboxSearch/gradle.properties
+++ b/MapboxSearch/gradle.properties
@@ -21,7 +21,7 @@ android.enableJetifier=false
 kotlin.code.style=official
 
 # SDK version attributes
-VERSION_NAME=1.0.0-beta.38
+VERSION_NAME=1.0.0-beta.38.1
 
 # Artifact attributes
 mapboxArtifactUserOrg=mapbox

--- a/MapboxSearch/ui/src/main/java/com/mapbox/search/ui/view/adapter/SearchViewResultsAdapter.kt
+++ b/MapboxSearch/ui/src/main/java/com/mapbox/search/ui/view/adapter/SearchViewResultsAdapter.kt
@@ -26,7 +26,7 @@ internal class SearchViewResultsAdapter(
         }
 
         override fun onPopulateQueryClick(item: SearchResultAdapterItem.Result) {
-            listener?.onResultItemClick(item)
+            listener?.onPopulateQueryClick(item)
         }
 
         override fun onMissingResultFeedbackClick(item: SearchResultAdapterItem.MissingResultFeedback) {


### PR DESCRIPTION
<!-- ⚠️ TEMPLATE ⚠️ -->
<!-- Template for GitHub PR descriptions. Use it as a guide on how to describe your work. Feel free to remove any section when you're opening a PR if you think it does not apply for your committed changes. -->

### Description
This PR:
- fixes a bug in the `SearchEngineUiAdapter`
- bumps SDK version to `1.0.0-beta.38.1`


### Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR (where applicable)
- [ ] I have run tests and automatic checks locally
- [ ] I have run `pitest` check locally and checked that the coverage increased (or didn't change) or decreased insignificantly
- [ ] I have made corresponding changes to the documentation (where applicable)
- [ ] I have grouped commits logically or I promise to squash my commits before merge
