### PR TITLE
Prevent DAO constructors from being removed by proguard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,11 @@
 
 ### Breaking changes
 - [CORE] `SearchAddress.FormatStyle.Custom` has been removed because it can't guarantee correct formatting behavior. `SearchAddress` provides all the address components with the existing public API and customers still can format address according to needed formatting rules.
+- [UI] `SearchResultsView.defaultSearchOptions` was not used and was removed from the API.
 
 ### Bug fixes
 - [CORE] Fixed a bug with `SearchAddress` formatting when address house number is empty.
-- [UI] `SearchResultsView.defaultSearchOptions` was not used and was removed from the API.
+- [CORE] Added a proguard rule that prevents DAO classes constructors from being removed.
 - [UI] Fixed a bug in `SearchResultsView` when incorrect search options was used for request retry.
 
 ### Mapbox dependencies

--- a/MapboxSearch/sample/src/main/java/com/mapbox/search/sample/MainActivity.kt
+++ b/MapboxSearch/sample/src/main/java/com/mapbox/search/sample/MainActivity.kt
@@ -503,6 +503,7 @@ class MainActivity : AppCompatActivity() {
     private fun showMarker(coordinate: Point) {
         val cameraOptions = CameraOptions.Builder()
             .center(coordinate)
+            .padding(EdgeInsets(.0, .0, dpToPx(300).toDouble(), .0))
             .zoom(10.0)
             .build()
 

--- a/MapboxSearch/sdk/proguard/consumer-proguard-sdk.txt
+++ b/MapboxSearch/sdk/proguard/consumer-proguard-sdk.txt
@@ -1,23 +1,4 @@
-# --- Bindgen-generated classes ---
--keep class com.mapbox.search.internal.bindgen.** {*;}
-
-# --- Mapbox SDKs ---
--keep class com.mapbox.geojson.** {*;}
--keep class com.mapbox.bindgen.** {*;}
-
-# --- GSON ---
-# This gson rule is too lenient, but official proguard config from gson doesn't work.
--keep class com.google.gson.** {*;}
--keepclassmembers enum * {
-    <fields>;
+# SDK Data Access Object classes
+-keepclassmembers,allowoptimization class * implements com.mapbox.search.utils.serialization.DataAccessObject {
+    <init>();
 }
--keepattributes Signature
--keepattributes *Annotation*
--dontwarn sun.misc.**
--keepclassmembers,allowobfuscation class * {
-    @com.google.gson.annotations.SerializedName <fields>;
-}
-
-# --- AutoValue ---
-# AutoValue annotations are retained but dependency is compileOnly.
--dontwarn com.google.auto.value.**


### PR DESCRIPTION
<!-- ⚠️ TEMPLATE ⚠️ -->
<!-- Template for GitHub PR descriptions. Use it as a guide on how to describe your work. Feel free to remove any section when you're opening a PR if you think it does not apply for your committed changes. -->

### Description
This PR adds proguard rule that prevents DAO classes constructors from being removed.

### Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have updated the `CHANGELOG` including this PR (where applicable)
- [x] I have run tests and automatic checks locally
- [ ] I have run `pitest` check locally and checked that the coverage increased (or didn't change) or decreased insignificantly
- [x] I have made corresponding changes to the documentation (where applicable)
- [x] I have grouped commits logically or I promise to squash my commits before merge
