### PR TITLE
update license file & generator script

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -4,14 +4,9 @@ Mapbox Search SDK for Android version 1.0
 
 Mapbox Search Android SDK
 
-Copyright &copy; 2021 Mapbox
+Copyright &copy; 2021 - 2023 Mapbox, Inc. All rights reserved.
 
-All rights reserved.
-
-Mapbox Search SDK for Android version 1.0 ("Mapbox Search Android SDK") or higher must be used according to the Mapbox Terms of Service. This license allows developers with a current active Mapbox account to use and modify the Mapbox Search Android SDK. Developers may modify the Mapbox Search Android SDK code so long as the modifications do not change or interfere with marked portions of the code related to billing, accounting, and anonymized data collection. The Mapbox Search Android SDK sends anonymized location and usage data, which Mapbox uses for fixing bugs and errors, accounting, and generating aggregated anonymized statistics. This license terminates automatically if a user no longer has an active Mapbox account.
-
-For the full license terms, please see the Mapbox Terms of Service at https://www.mapbox.com/legal/tos/
-
+The software and files in this repository (collectively, "Software") are licensed under the Mapbox TOS for use only with the relevant Mapbox product(s) listed at www.mapbox.com/pricing. This license allows developers with a current active Mapbox account to use and modify the authorized portions of the Software as needed for use only with the relevant Mapbox product(s) through their Mapbox account in accordance with the Mapbox TOS.  This license terminates automatically if a developer no longer has a Mapbox account in good standing or breaches the Mapbox TOS. For the license terms, please see the Mapbox TOS at https://www.mapbox.com/legal/tos/ which incorporates the Mapbox Product Terms at www.mapbox.com/legal/service-terms.  If this Software is a SDK, modifications that change or interfere with marked portions of the code related to billing, accounting, or data collection are not authorized and the SDK sends limited de-identified location and usage data which is used in accordance with the Mapbox TOS. [Updated 2023-01]
 ---------------------------------------
 URL: [Gradle License Plugin](https://github.com/jaredsburrows/gradle-license-plugin)  
 License: [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)

--- a/scripts/license-generate.py
+++ b/scripts/license-generate.py
@@ -1,23 +1,24 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 import json
 import os
 import sys
+import datetime
 
 path = os.getcwd() + "/MapboxSearch"
 licenseFilePath = os.getcwd() + "/LICENSE.md"
 
 def writeDependency(licenseFile, projectName, projectUrl, licenseName, licenseUrl):
-    licenseFile.write("Mapbox Search Android uses portions of the %s.  \n" % projectName +
-                        ("URL: [%s](%s)  \n" % (projectUrl, projectUrl) if projectUrl is not None else "") +
-                        "License: [%s](%s)" % (licenseName, licenseUrl) +
+    licenseFile.write("Mapbox Search Android uses portions of the {}.  \n".format(projectName) +
+                        ("URL: [{}]({})  \n".format(projectUrl, projectUrl) if projectUrl is not None else "") +
+                        "License: [{}]({})".format(licenseName, licenseUrl) +
                         "\n\n===========================================================================\n\n")
 
 def generateLicense(licenseFile, moduleName):
     try:
         # run gradle license generation
-        os.system("cd MapboxSearch && ./gradlew %s:licenseReleaseReport" % moduleName)
+        os.system("cd MapboxSearch && ./gradlew {}:licenseReleaseReport".format(moduleName))
 
-        with open(path + "/%s/build/reports/licenses/licenseReleaseReport.json" % moduleName, 'r') as dataFile:
+        with open(path + "/{}/build/reports/licenses/licenseReleaseReport.json".format(moduleName), 'r') as dataFile:
             data = json.load(dataFile)
 
             uniqueProjects = set()
@@ -32,24 +33,21 @@ def generateLicense(licenseFile, moduleName):
                         licenseUrl = license["license_url"]
                         writeDependency(licenseFile, projectName, projectUrl, licenseName, licenseUrl)
 
-    except IOError as (errno,strerror):
-        print "I/O error(%s): %s" % (errno, strerror)
+    except IOError as err:
+        print("I/O error: {}".format(str(err)))
 
 try:
     with open(licenseFilePath, 'w+') as licenseFile:
+        now = datetime.datetime.now()
         licenseFile.write("### License\n")
         licenseFile.write("\n")
         licenseFile.write("Mapbox Search SDK for Android version 1.0\n")
         licenseFile.write("\n")
         licenseFile.write("Mapbox Search Android SDK\n")
         licenseFile.write("\n")
-        licenseFile.write("Copyright &copy; 2021 Mapbox\n")
+        licenseFile.write("Copyright &copy; 2021 - {} Mapbox, Inc. All rights reserved.\n".format(now.year))
         licenseFile.write("\n")
-        licenseFile.write("All rights reserved.\n")
-        licenseFile.write("\n")
-        licenseFile.write("Mapbox Search SDK for Android version 1.0 (\"Mapbox Search Android SDK\") or higher must be used according to the Mapbox Terms of Service. This license allows developers with a current active Mapbox account to use and modify the Mapbox Search Android SDK. Developers may modify the Mapbox Search Android SDK code so long as the modifications do not change or interfere with marked portions of the code related to billing, accounting, and anonymized data collection. The Mapbox Search Android SDK sends anonymized location and usage data, which Mapbox uses for fixing bugs and errors, accounting, and generating aggregated anonymized statistics. This license terminates automatically if a user no longer has an active Mapbox account.\n")
-        licenseFile.write("\n")
-        licenseFile.write("For the full license terms, please see the Mapbox Terms of Service at https://www.mapbox.com/legal/tos/\n")
+        licenseFile.write("The software and files in this repository (collectively, \"Software\") are licensed under the Mapbox TOS for use only with the relevant Mapbox product(s) listed at www.mapbox.com/pricing. This license allows developers with a current active Mapbox account to use and modify the authorized portions of the Software as needed for use only with the relevant Mapbox product(s) through their Mapbox account in accordance with the Mapbox TOS.  This license terminates automatically if a developer no longer has a Mapbox account in good standing or breaches the Mapbox TOS. For the license terms, please see the Mapbox TOS at https://www.mapbox.com/legal/tos/ which incorporates the Mapbox Product Terms at www.mapbox.com/legal/service-terms.  If this Software is a SDK, modifications that change or interfere with marked portions of the code related to billing, accounting, or data collection are not authorized and the SDK sends limited de-identified location and usage data which is used in accordance with the Mapbox TOS. [Updated {}-{:02d}]".format(now.year, now.month))
         licenseFile.write("\n")
         licenseFile.write("---------------------------------------\n")
 
@@ -57,7 +55,7 @@ try:
         url = "https://github.com/jaredsburrows/gradle-license-plugin"
         license = "The Apache Software License, Version 2.0"
         license_url = "http://www.apache.org/licenses/LICENSE-2.0.txt"
-        licenseFile.write("URL: [%s](%s)  \n" % (project, url) + "License: [%s](%s)" % (license, license_url))
+        licenseFile.write("URL: [{}]({})  \n".format(project, url) + "License: [{}]({})".format(license, license_url))
 
         licenseFile.write("\n\n#### Search Base module\n")
         generateLicense(licenseFile, "base")


### PR DESCRIPTION
- update license text to reflect latest version
- update generator script to include new text, automate year handling, move to python3

please note that while I've made similar changes in our other projects, this is the first license generator script I've run across that's still using python2. my revisions to python3 string substitution syntax are complete, but I didn't take the time to get a gradle environment running for the project and don't know if CI or other parts of your toolchain are stuck on python2 for some reason. if they are please let me know and I can dig deeper/get this project fully built instead of taking the quick approach.