### PR TITLE
Crash fix; New default tiles dataset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 1.0.0-beta.45-SNAPSHOT
 
+### Bug fixes
+- [CORE] Fix a crash that could happen during unexpected backend metadata response.
+- [OFFLINE] Update default tiles dataset name.
+
 ### Mapbox dependencies
 - Search Native SDK `0.66.0`
 - Common SDK `23.2.1`

--- a/MapboxSearch/base/src/main/java/com/mapbox/search/base/MetadataExt.kt
+++ b/MapboxSearch/base/src/main/java/com/mapbox/search/base/MetadataExt.kt
@@ -11,11 +11,21 @@ import com.mapbox.search.common.metadata.ParkingData
 import com.mapbox.search.common.metadata.WeekDay
 import com.mapbox.search.common.metadata.WeekTimestamp
 
-public fun CoreOpenHours.mapToPlatform() = when (mode) {
+public fun CoreOpenHours.mapToPlatform(): OpenHours? = when (mode) {
     CoreOpenMode.ALWAYS_OPEN -> OpenHours.AlwaysOpen
     CoreOpenMode.TEMPORARILY_CLOSED -> OpenHours.TemporaryClosed
     CoreOpenMode.PERMANENTLY_CLOSED -> OpenHours.PermanentlyClosed
-    CoreOpenMode.SCHEDULED -> OpenHours.Scheduled(periods = periods.map { it.mapToPlatform() })
+    CoreOpenMode.SCHEDULED -> {
+        val periods = periods.map { it.mapToPlatform() }
+        if (periods.isEmpty()) {
+            failDebug {
+                "CoreOpenHours type is SCHEDULED, but periods is empty"
+            }
+            null
+        } else {
+            OpenHours.Scheduled(periods = periods)
+        }
+    }
 }
 
 public fun OpenHours.mapToCore() = when (this) {

--- a/MapboxSearch/offline/api/api-metalava.txt
+++ b/MapboxSearch/offline/api/api-metalava.txt
@@ -94,11 +94,11 @@ package com.mapbox.search.offline {
     method public void addOnIndexChangeListener(java.util.concurrent.Executor executor, com.mapbox.search.offline.OfflineSearchEngine.OnIndexChangeListener listener);
     method public default void addOnIndexChangeListener(com.mapbox.search.offline.OfflineSearchEngine.OnIndexChangeListener listener);
     method public default static com.mapbox.search.offline.OfflineSearchEngine create(com.mapbox.search.offline.OfflineSearchEngineSettings settings);
-    method public default static com.mapbox.common.TilesetDescriptor createPlacesTilesetDescriptor(String dataset = "test-dataset", String version = "");
-    method public default static final com.mapbox.common.TilesetDescriptor createPlacesTilesetDescriptor(String dataset = "test-dataset");
+    method public default static com.mapbox.common.TilesetDescriptor createPlacesTilesetDescriptor(String dataset = "mbx-main", String version = "");
+    method public default static final com.mapbox.common.TilesetDescriptor createPlacesTilesetDescriptor(String dataset = "mbx-main");
     method public default static final com.mapbox.common.TilesetDescriptor createPlacesTilesetDescriptor();
-    method public default static com.mapbox.common.TilesetDescriptor createTilesetDescriptor(String dataset = "test-dataset", String version = "");
-    method public default static final com.mapbox.common.TilesetDescriptor createTilesetDescriptor(String dataset = "test-dataset");
+    method public default static com.mapbox.common.TilesetDescriptor createTilesetDescriptor(String dataset = "mbx-main", String version = "");
+    method public default static final com.mapbox.common.TilesetDescriptor createTilesetDescriptor(String dataset = "mbx-main");
     method public default static final com.mapbox.common.TilesetDescriptor createTilesetDescriptor();
     method public com.mapbox.search.offline.OfflineSearchEngineSettings getSettings();
     method public void removeEngineReadyCallback(com.mapbox.search.offline.OfflineSearchEngine.EngineReadyCallback callback);
@@ -116,11 +116,11 @@ package com.mapbox.search.offline {
 
   public static final class OfflineSearchEngine.Companion {
     method public com.mapbox.search.offline.OfflineSearchEngine create(com.mapbox.search.offline.OfflineSearchEngineSettings settings);
-    method public com.mapbox.common.TilesetDescriptor createPlacesTilesetDescriptor(String dataset = "test-dataset", String version = "");
-    method public com.mapbox.common.TilesetDescriptor createPlacesTilesetDescriptor(String dataset = "test-dataset");
+    method public com.mapbox.common.TilesetDescriptor createPlacesTilesetDescriptor(String dataset = "mbx-main", String version = "");
+    method public com.mapbox.common.TilesetDescriptor createPlacesTilesetDescriptor(String dataset = "mbx-main");
     method public com.mapbox.common.TilesetDescriptor createPlacesTilesetDescriptor();
-    method public com.mapbox.common.TilesetDescriptor createTilesetDescriptor(String dataset = "test-dataset", String version = "");
-    method public com.mapbox.common.TilesetDescriptor createTilesetDescriptor(String dataset = "test-dataset");
+    method public com.mapbox.common.TilesetDescriptor createTilesetDescriptor(String dataset = "mbx-main", String version = "");
+    method public com.mapbox.common.TilesetDescriptor createTilesetDescriptor(String dataset = "mbx-main");
     method public com.mapbox.common.TilesetDescriptor createTilesetDescriptor();
   }
 
@@ -147,7 +147,7 @@ package com.mapbox.search.offline {
     property public final com.mapbox.android.core.location.LocationEngine locationEngine;
     property public final com.mapbox.common.TileStore tileStore;
     property public final java.net.URI tilesBaseUri;
-    field public static final String DEFAULT_DATASET = "test-dataset";
+    field public static final String DEFAULT_DATASET = "mbx-main";
     field public static final String DEFAULT_VERSION = "";
   }
 

--- a/MapboxSearch/offline/src/androidTest/java/com/mapbox/search/offline/OfflineSearchEngineIntegrationTest.kt
+++ b/MapboxSearch/offline/src/androidTest/java/com/mapbox/search/offline/OfflineSearchEngineIntegrationTest.kt
@@ -304,7 +304,7 @@ internal class OfflineSearchEngineIntegrationTest {
         assertTrue(searchEngineResult is SearchEngineResult.Results)
 
         val results = searchEngineResult.requireResults()
-        assertEquals(9, results.size)
+        assertEquals(10, results.size)
 
         val result = results.first()
         val rawSearchResult = result.rawSearchResult
@@ -522,7 +522,7 @@ internal class OfflineSearchEngineIntegrationTest {
             ),
             descriptionAddress = "2011 15th Street Northwest, Washington, District of Columbia",
             distanceMeters = 0.0,
-            center = Point.fromLngLat(-77.03401323039313, 38.91793457393481),
+            center = Point.fromLngLat(-77.03402549505554, 38.91792475903431),
             serverIndex = null,
         )
 

--- a/MapboxSearch/offline/src/main/java/com/mapbox/search/offline/OfflineSearchEngineSettings.kt
+++ b/MapboxSearch/offline/src/main/java/com/mapbox/search/offline/OfflineSearchEngineSettings.kt
@@ -151,7 +151,7 @@ public class OfflineSearchEngineSettings @JvmOverloads constructor(
     internal companion object {
 
         val DEFAULT_ENDPOINT_URI: URI = URI.create("https://api.mapbox.com")
-        const val DEFAULT_DATASET = "test-dataset"
+        const val DEFAULT_DATASET = "mbx-main"
         const val DEFAULT_VERSION = ""
 
         private fun defaultTileStore() = TileStore.create()

--- a/MapboxSearch/offline/src/test/java/com/mapbox/search/offline/OfflineSearchEngineSettingsTest.kt
+++ b/MapboxSearch/offline/src/test/java/com/mapbox/search/offline/OfflineSearchEngineSettingsTest.kt
@@ -45,7 +45,7 @@ internal class OfflineSearchEngineSettingsTest {
 
                 Then(
                     "Default dataset should be as expected",
-                    "test-dataset",
+                    "mbx-main",
                     OfflineSearchEngineSettings.DEFAULT_DATASET
                 )
 

--- a/MapboxSearch/sample/src/main/java/com/mapbox/search/sample/api/DiscoverApiKotlinExampleActivity.kt
+++ b/MapboxSearch/sample/src/main/java/com/mapbox/search/sample/api/DiscoverApiKotlinExampleActivity.kt
@@ -12,12 +12,10 @@ import com.mapbox.search.sample.R
 
 class DiscoverApiKotlinExampleActivity : AppCompatActivity() {
 
-    private lateinit var discoverApi: DiscoverApi
-
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        discoverApi = DiscoverApi.create(
+        val discoverApi = DiscoverApi.create(
             accessToken = getString(R.string.mapbox_access_token),
         )
 
@@ -27,12 +25,12 @@ class DiscoverApiKotlinExampleActivity : AppCompatActivity() {
                 Point.fromLngLat(-77.02584649998599, 38.907104458514695)
             )
 
-            val result = discoverApi.search(
+            val response = discoverApi.search(
                 query = DiscoverApiQuery.Category.COFFEE_SHOP_CAFE,
                 region = dcRegion
             )
 
-            result.onValue { results ->
+            response.onValue { results ->
                 Log.i("SearchApiExample", "Discover API results: $results")
             }.onError { e ->
                 Log.i("SearchApiExample", "Discover API error", e)

--- a/MapboxSearch/sample/src/main/java/com/mapbox/search/sample/api/OfflineSearchJavaExampleActivity.java
+++ b/MapboxSearch/sample/src/main/java/com/mapbox/search/sample/api/OfflineSearchJavaExampleActivity.java
@@ -81,7 +81,7 @@ public class OfflineSearchJavaExampleActivity extends AppCompatActivity {
                     Log.i("SearchApiExample", tileRegionId + " was successfully added or updated");
 
                     searchRequestTask = searchEngine.search(
-                        "Cafe",
+                        "2011 15th Street Northwest, Washington, District of Columbia",
                         new OfflineSearchOptions(),
                         searchCallback
                     );

--- a/MapboxSearch/sample/src/main/java/com/mapbox/search/sample/api/OfflineSearchKotlinExampleActivity.kt
+++ b/MapboxSearch/sample/src/main/java/com/mapbox/search/sample/api/OfflineSearchKotlinExampleActivity.kt
@@ -73,7 +73,7 @@ class OfflineSearchKotlinExampleActivity : Activity() {
                     Log.i("SearchApiExample", "$tileRegionId was successfully added or updated")
 
                     searchRequestTask = searchEngine.search(
-                        "Cafe",
+                        "2011 15th Street Northwest, Washington, District of Columbia",
                         OfflineSearchOptions(),
                         searchCallback
                     )

--- a/MapboxSearch/sdk/src/main/java/com/mapbox/search/utils/serialization/OpenHoursDAO.kt
+++ b/MapboxSearch/sdk/src/main/java/com/mapbox/search/utils/serialization/OpenHoursDAO.kt
@@ -23,7 +23,11 @@ internal class OpenHoursDAO(
             OpenModeDAO.PERMANENTLY_CLOSED -> OpenHours.PermanentlyClosed
             OpenModeDAO.SCHEDULED -> {
                 val validPeriods = periods?.filter { it.isValid }?.map { it.createData() }
-                OpenHours.Scheduled(periods = validPeriods!!)
+                if (validPeriods.isNullOrEmpty()) {
+                    error("OpenHours.periods must not be empty")
+                } else {
+                    OpenHours.Scheduled(periods = validPeriods)
+                }
             }
         }
     }


### PR DESCRIPTION
<!-- ⚠️ TEMPLATE ⚠️ -->
<!-- Template for GitHub PR descriptions. Use it as a guide on how to describe your work. Feel free to remove any section when you're opening a PR if you think it does not apply for your committed changes. -->

### Description
This PR
- fixes a crash that could happen during unexpected backend metadata response.
- updates default offline tiles dataset name.


### Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have updated the `CHANGELOG` including this PR (where applicable)
- [x] I have run tests and automatic checks locally
- [ ] I have run `pitest` check locally and checked that the coverage increased (or didn't change) or decreased insignificantly
- [x] I have made corresponding changes to the documentation (where applicable)
- [x] I have grouped commits logically or I promise to squash my commits before merge
