### PR TITLE
Prefer data from server for matched with indexable records search suggestions and results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog for the Mapbox Search SDK for Android
 
+## 1.0.0-rc.6-SNAPSHOT
+
+### Breaking changes
+- [CORE] `SearchSuggestionType.IndexableRecordItem.type` field has been replaced with `record` field which provides `IndexableRecord` instance.
+
+### Bug fixes
+- [CORE] Now search suggestions and search results that are matched with `IndexableRecord`s provide data from the backend which is likely to be up-to-date than data from `IndexableRecord`. Original `IndexableRecord` instance can be obtained from `SearchSuggestionType.IndexableRecordItem.record` and `SearchResult.indexableRecord`.
+
+### Mapbox dependencies
+- Search Native SDK `0.69.0`
+- Common SDK `23.6.0-rc.1`
+- Kotlin `1.5.31`
+
+
+
 ## 1.0.0-rc.5
 
 ### New features

--- a/MapboxSearch/base/src/main/java/com/mapbox/search/base/result/BaseIndexableRecordSearchResultImpl.kt
+++ b/MapboxSearch/base/src/main/java/com/mapbox/search/base/result/BaseIndexableRecordSearchResultImpl.kt
@@ -19,33 +19,32 @@ data class BaseIndexableRecordSearchResultImpl(
     override val baseType: Type = Type.IndexableRecordSearchResult(record)
 
     override val id: String
-        get() = record.id
+        get() = rawSearchResult.userRecordId ?: rawSearchResult.id
 
     override val name: String
         get() = record.name
 
     override val descriptionText: String?
-        get() = record.descriptionText
+        get() = rawSearchResult.descriptionAddress ?: record.descriptionText
 
     override val address: BaseSearchAddress?
-        get() = record.address ?: rawSearchResult.addresses?.get(0)
+        get() = rawSearchResult.addresses?.first() ?: record.address
 
     override val coordinate: Point
-        get() = record.coordinate
+        get() = rawSearchResult.center ?: record.coordinate
 
     override val routablePoints: List<CoreRoutablePoint>?
-        get() = record.routablePoints
+        get() = rawSearchResult.routablePoints ?: record.routablePoints
 
-    // TODO(search-sdk/#526): consider multiple types for IndexableRecord
     override val types: List<BaseSearchResultType>
         get() = listOf(record.type)
 
     override val categories: List<String>?
-        get() = record.categories ?: super.categories
+        get() = rawSearchResult.categories ?: record.categories
 
     override val makiIcon: String?
-        get() = record.makiIcon
+        get() = rawSearchResult.icon ?: record.makiIcon
 
     override val metadata: CoreResultMetadata?
-        get() = record.metadata
+        get() = rawSearchResult.metadata ?: record.metadata
 }

--- a/MapboxSearch/base/src/main/java/com/mapbox/search/base/result/BaseIndexableRecordSearchSuggestion.kt
+++ b/MapboxSearch/base/src/main/java/com/mapbox/search/base/result/BaseIndexableRecordSearchSuggestion.kt
@@ -1,6 +1,9 @@
 package com.mapbox.search.base.result
 
+import com.mapbox.geojson.Point
 import com.mapbox.search.base.BaseRequestOptions
+import com.mapbox.search.base.core.CoreResultMetadata
+import com.mapbox.search.base.core.CoreRoutablePoint
 import com.mapbox.search.base.record.BaseIndexableRecord
 import kotlinx.parcelize.Parcelize
 
@@ -22,18 +25,30 @@ data class BaseIndexableRecordSearchSuggestion(
     override val name: String
         get() = record.name
 
-    override val address: BaseSearchAddress?
-        get() = record.address
+    override val coordinate: Point
+        get() = rawSearchResult.center ?: record.coordinate
 
-    override val type: BaseSearchSuggestionType.IndexableRecordItem
-        get() = BaseSearchSuggestionType.IndexableRecordItem(rawSearchResult.layerId!!, record.type)
+    override val routablePoints: List<CoreRoutablePoint>?
+        get() = rawSearchResult.routablePoints ?: record.routablePoints
 
     override val descriptionText: String?
-        get() = record.descriptionText
+        get() = rawSearchResult.descriptionAddress ?: record.descriptionText
+
+    override val address: BaseSearchAddress?
+        get() = rawSearchResult.addresses?.first() ?: record.address
+
+    override val categories: List<String>?
+        get() = rawSearchResult.categories ?: record.categories
+
+    override val makiIcon: String?
+        get() = rawSearchResult.icon ?: record.makiIcon
+
+    override val metadata: CoreResultMetadata?
+        get() = rawSearchResult.metadata ?: record.metadata
+
+    override val type: BaseSearchSuggestionType.IndexableRecordItem
+        get() = BaseSearchSuggestionType.IndexableRecordItem(record, rawSearchResult.layerId!!)
 
     override val isBatchResolveSupported: Boolean
         get() = true
-
-    override val makiIcon: String?
-        get() = record.makiIcon
 }

--- a/MapboxSearch/base/src/main/java/com/mapbox/search/base/result/BaseSearchSuggestionType.kt
+++ b/MapboxSearch/base/src/main/java/com/mapbox/search/base/result/BaseSearchSuggestionType.kt
@@ -2,6 +2,7 @@ package com.mapbox.search.base.result
 
 import android.os.Parcelable
 import com.mapbox.search.base.assertDebug
+import com.mapbox.search.base.record.BaseIndexableRecord
 import kotlinx.parcelize.Parcelize
 
 sealed class BaseSearchSuggestionType : Parcelable {
@@ -27,7 +28,7 @@ sealed class BaseSearchSuggestionType : Parcelable {
 
     @Parcelize
     data class IndexableRecordItem internal constructor(
+        val record: BaseIndexableRecord,
         val dataProviderName: String,
-        val type: BaseSearchResultType,
     ) : BaseSearchSuggestionType()
 }

--- a/MapboxSearch/base/src/test/java/com/mapbox/search/base/result/BaseSearchSuggestionTest.kt
+++ b/MapboxSearch/base/src/test/java/com/mapbox/search/base/result/BaseSearchSuggestionTest.kt
@@ -268,7 +268,7 @@ internal class BaseSearchSuggestionTest {
 
                 Then(
                     "Suggestion type value should be derived from core search result",
-                    BaseSearchSuggestionType.IndexableRecordItem(searchResult.layerId!!, TEST_RECORD.type),
+                    BaseSearchSuggestionType.IndexableRecordItem(TEST_RECORD, searchResult.layerId!!),
                     suggestion.type
                 )
 

--- a/MapboxSearch/gradle.properties
+++ b/MapboxSearch/gradle.properties
@@ -21,7 +21,7 @@ android.enableJetifier=false
 kotlin.code.style=official
 
 # SDK version attributes
-VERSION_NAME=1.0.0-rc.5
+VERSION_NAME=1.0.0-rc.6-SNAPSHOT
 
 # Artifact attributes
 mapboxArtifactUserOrg=mapbox

--- a/MapboxSearch/sdk/api/api-metalava.txt
+++ b/MapboxSearch/sdk/api/api-metalava.txt
@@ -883,13 +883,13 @@ package com.mapbox.search.result {
 
   @kotlinx.parcelize.Parcelize public static final class SearchSuggestionType.IndexableRecordItem extends com.mapbox.search.result.SearchSuggestionType {
     method public String getDataProviderName();
-    method public com.mapbox.search.result.SearchResultType getType();
+    method public com.mapbox.search.record.IndexableRecord getRecord();
     method public boolean isFavoriteRecord();
     method public boolean isHistoryRecord();
     property public final String dataProviderName;
     property public final boolean isFavoriteRecord;
     property public final boolean isHistoryRecord;
-    property public final com.mapbox.search.result.SearchResultType type;
+    property public final com.mapbox.search.record.IndexableRecord record;
   }
 
   @kotlinx.parcelize.Parcelize public static final class SearchSuggestionType.Query extends com.mapbox.search.result.SearchSuggestionType {

--- a/MapboxSearch/sdk/api/sdk.api
+++ b/MapboxSearch/sdk/api/sdk.api
@@ -947,7 +947,7 @@ public final class com/mapbox/search/result/SearchSuggestionType$IndexableRecord
 	public fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getDataProviderName ()Ljava/lang/String;
-	public final fun getType ()Lcom/mapbox/search/result/SearchResultType;
+	public final fun getRecord ()Lcom/mapbox/search/record/IndexableRecord;
 	public fun hashCode ()I
 	public final fun isFavoriteRecord ()Z
 	public final fun isHistoryRecord ()Z

--- a/MapboxSearch/sdk/src/androidTest/assets/sbs_responses/suggestions-successful-for-indexable-records-matching.json
+++ b/MapboxSearch/sdk/src/androidTest/assets/sbs_responses/suggestions-successful-for-indexable-records-matching.json
@@ -1,0 +1,92 @@
+{
+  "suggestions": [
+    {
+      "feature_name": "Starbucks",
+      "matching_name": "Starbucks",
+      "highlighted_name": "Starbucks",
+      "description": "150 Van Ness, San Francisco, California 94102, United States of America",
+      "result_type": [
+        "poi"
+      ],
+      "language": "en",
+      "action": {
+        "endpoint": "retrieve",
+        "method": "POST",
+        "body": {
+          "id": "0pATHR-w9JNNQBieDzjDxRAy6QJoWrT-YvbsBNmkw-EUbQSWZMJ1wpr06E-y3n2mjsmq7sGpAGjE6TMV0qz8y9y5qqFlPH_XVf31T47Gczpja-6yh5Fofa8_qxBPLa8DsJrFItFlgwTUx58Fp_b971Ht_CpbnjFOTArxbGkSqvJ3iZVTH3E2W9g7OTjy2v4rjUAxVeUp18ajnsp5XfhqRHdd6H1tKvTcwHLF1PDRuKKkyDaEby-vjKXDD_kkE6zLp22M8ALt85tIRxJunQZQImOUS1t6lhBUGo8aOWPdvV3BtgCkjntDP7CD-lgCYN-j4_pv5ggBeFgh0zlQUrHkPE9D79ZXzW60G2utr9EWRQ8dlwuj7xOF3LsT7tnu4fp6LsCPeLjDioJ88lh5B4dAhnRdrmWP6xHNnKmEcnpjr34rrPOWvj_tdb9V4ISrFnejzlCwciYahZ8TUy_rDtyiW5M188pEFObx-OH6q7A8_nJ62LDGsOOiMBk5ZomUgsmgaDSh3HAMS2tZ_1ViTgSZpRVYXa1Y6LJbmMLTiFXLtdg6tWrI7h88XcH0qG7pGbMLNXulLoZEOpiWcOpyZeoATPbnJduS7XjGjUIaP4c0VZiaFmnfW-O_R7mJWhE-ibcLUO11cUHZPs5liOmtGE5MqeJuAnURtBSoiyNp2qs5iX5R0NhBnOYpiPeUKP0mtnJudED--H_9ewYLWM4I--b44ljpNbJIZdJqW0jeEK1ellyrC6DdUHjhq_to8WrZlCEk_3-4OviHnUQ2e5vEhLF6t9rfgN5KvZPBUHjz5RclLEGSvbF7KKdk5A8PGcVnfE3vycmgtKtkCXerIrYy7wBrONiYprcT-X-LVUIEc_-yPc7VwgsiiG2Mlne1qlYur5PCT2CM9y9-1ao0sw1wimAQKEJnvL1T79HfOlVkvr9nnN0rdjbWJvnbP_dM0dfPDTZHGedp1bB144O32A1mLtoK6CXxRk7Ie7FDFQlHDnWhC54F3VsN-Vdpzu6ybe0XJD3okOqXDJKTYsGLWNZy5hwQuuVV54te4g1yhfkJJ3GmRfSBp24ipOpMVjm5l53bDPsmyWu0xtEh7eV8VFCUg-1Wyr4ESEipWShB8kPjZfcInYnR1baVFHJhaxVpBsEAm2pAaLTuzErfu1wtV8Kq64itWWF0N3EtGsYQeEBKEYekfjMS1JCy2iEdSmXhwu_k6Eq5QhtcZcS-OyYGY7QCP-RCTZjyU3zdyjabOBDkp4EOCIqe31nRGhPK5OMOySxPdhKSHPPidJu--_OUSmMDCruiNzBHPHkDi7wB2fB5GQ0U600BJKVjB77XZ7sEud2pmBTx4KflPXJcCkSzMlsraZKPOyNAbUjDt-L4JhlNh48CkuQmWMUzH5UpGsLYi7CGXRipSoi3nHk4A6iwO2bXupnWUNL8gKXpGKeU0u6i3bd-SKC2uXMMmoNCn09nfpqKeGtYQ63fgqWMUicMLOKPFqbV4lY13XlcxDp5ugDCXAKCYwX5uUugHXONNG2xzaA9V4QQhO1rlLbkJqhm039rdGCH1D70NrbIG6Qa2_Nh-nyJBl3CvwWhdjjGZC3dWS7X5CpkqdHUhe6EiuBP4ar4VPQ6dbbITdTWMh-c4_WKXGvhZ2llqJ00ZPo4AajKeNlMX777qcOqJhpNsXhQfNuGaCVSJ2LcCRlStoynOx10o3KH-8smC84_tVZubcCp2mTybXNp5EKwqPRFfvYfvOoIboPm1r7k7dXkhXJlPZV9BJGWKd0aFAisSZoZFx3SINO88fx_7rrG0BP-OOn-aPntdpj38PF76uz7JZun69Oc-hHNZLE8RQZeqLeJiaycywintU2w_mUAQ52_ykCRgi9ikNhWhYEW5ZBBnrU2XayEmp9d_88-VZ_3OhnUSIgx4pIbjBe38sif1RCuk2eUzYxSo3mhbeniJqudQAvW3Q44JAolJz15Ouu9qDzEpbCGXg=="
+        },
+        "multi_retrievable": true
+      },
+      "routable_points": [
+        {
+          "name": "POI",
+          "coordinates": [
+            -122.419548,
+            37.777044
+          ]
+        }
+      ],
+      "distance": 0,
+      "maki": "restaurant",
+      "category": [
+        "cafe"
+      ],
+      "category_ids": [
+        "cafe"
+      ],
+      "brand": [
+        "Starbucks"
+      ],
+      "brand_id": "starbucks",
+      "internal_id": "Y2aAgIL8TAA=.42eAgMSCTN2C_Ezd4tSisszkVAA=.Jcq5EcAwCARAlwTi9JC5Fd7-S7BntPG-z4XeaTsljEgqwIUOmhin5nIWJMly8kFcDt7xV5xQTumpah8=",
+      "external_ids": {
+        "mbx_poi": "4f7da7d3ca003ec41e4fc05428e56b134d036b0b201eb417cd3c48c91d3f599a",
+        "federated": "poi.4f7da7d3ca003ec41e4fc05428e56b134d036b0b201eb417cd3c48c91d3f599a"
+      },
+      "mapbox_id": "CkIKQDRmN2RhN2QzY2EwMDNlYzQxZTRmYzA1NDI4ZTU2YjEzNGQwMzZiMGIyMDFlYjQxN2NkM2M0OGM5MWQzZjU5OWE=",
+      "context": [
+        {
+          "layer": "address",
+          "localized_layer": "address",
+          "name": "150 Van Ness"
+        },
+        {
+          "layer": "street",
+          "localized_layer": "street",
+          "name": "van ness"
+        },
+        {
+          "layer": "postcode",
+          "localized_layer": "postcode",
+          "name": "94102"
+        },
+        {
+          "layer": "neighborhood",
+          "localized_layer": "neighborhood",
+          "name": "Downtown"
+        },
+        {
+          "layer": "place",
+          "localized_layer": "place",
+          "name": "San Francisco"
+        },
+        {
+          "layer": "region",
+          "localized_layer": "region",
+          "name": "California"
+        },
+        {
+          "layer": "country",
+          "localized_layer": "country",
+          "name": "United States of America"
+        }
+      ],
+      "metadata": {
+        "iso_3166_1": "US"
+      }
+    }
+  ],
+  "attribution": "© 2023 Mapbox and its suppliers. All rights reserved. Use of this data is subject to the Mapbox Terms of Service. (https://www.mapbox.com/about/maps/)",
+  "version": "137:1ba5d765ac9795bff7c71daa61c7b04c262da744",
+  "response_uuid": "dd9ffbae-96ce-47fa-800f-05ae0b9970a8"
+}

--- a/MapboxSearch/sdk/src/main/java/com/mapbox/search/result/SearchSuggestion.kt
+++ b/MapboxSearch/sdk/src/main/java/com/mapbox/search/result/SearchSuggestion.kt
@@ -218,8 +218,8 @@ internal fun BaseSearchSuggestion.getSearchSuggestionType(): SearchSuggestionTyp
         )
         is BaseSearchSuggestionType.Query -> SearchSuggestionType.Query
         is BaseSearchSuggestionType.IndexableRecordItem -> SearchSuggestionType.IndexableRecordItem(
+            t.record.sdkResolvedRecord as IndexableRecord,
             t.dataProviderName,
-            t.type.mapToPlatform()
         )
     }
 }

--- a/MapboxSearch/sdk/src/main/java/com/mapbox/search/result/SearchSuggestionType.kt
+++ b/MapboxSearch/sdk/src/main/java/com/mapbox/search/result/SearchSuggestionType.kt
@@ -147,15 +147,15 @@ public abstract class SearchSuggestionType internal constructor() : Parcelable {
     public object Query : SearchSuggestionType()
 
     /**
-     * Search suggestion of the [IndexableRecordItem] type points to the search results with [IndexableRecord] that will be returned after selection.
+     * Search suggestion of the [IndexableRecordItem] type points to the search result based on [IndexableRecord].
      *
+     * @property record - [IndexableRecord] that was matched with a search query.
      * @property dataProviderName - the id of the data provider.
-     * @property type - type of the [com.mapbox.search.record.IndexableRecord] that will be resolved after selection of the search suggestion.
      */
     @Parcelize
     public class IndexableRecordItem internal constructor(
+        public val record: IndexableRecord,
         public val dataProviderName: String,
-        public val type: SearchResultType,
     ) : SearchSuggestionType() {
 
         /**
@@ -179,8 +179,8 @@ public abstract class SearchSuggestionType internal constructor() : Parcelable {
 
             other as IndexableRecordItem
 
+            if (record != other.record) return false
             if (dataProviderName != other.dataProviderName) return false
-            if (type != other.type) return false
 
             return true
         }
@@ -189,8 +189,8 @@ public abstract class SearchSuggestionType internal constructor() : Parcelable {
          * @suppress
          */
         override fun hashCode(): Int {
-            var result = dataProviderName.hashCode()
-            result = 31 * result + type.hashCode()
+            var result = record.hashCode()
+            result = 31 * result + dataProviderName.hashCode()
             return result
         }
 
@@ -198,7 +198,7 @@ public abstract class SearchSuggestionType internal constructor() : Parcelable {
          * @suppress
          */
         override fun toString(): String {
-            return "IndexableRecordItem(dataProviderName='$dataProviderName', type=$type)"
+            return "IndexableRecordItem(record=$record, dataProviderName='$dataProviderName')"
         }
     }
 }


### PR DESCRIPTION


<!-- ⚠️ TEMPLATE ⚠️ -->
<!-- Template for GitHub PR descriptions. Use it as a guide on how to describe your work. Feel free to remove any section when you're opening a PR if you think it does not apply for your committed changes. -->

### Description
This PR fixes `SearchSuggestion` and `SearchResult`s that are matched with `IndexableRecord`. Now such suggestions and results provide data from backend which is likely to be up-to-date. Original `IndexableRecord` still can be accessed via public api.

### Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have updated the `CHANGELOG` including this PR (where applicable)
- [x] I have run tests and automatic checks locally
- [ ] I have run `pitest` check locally and checked that the coverage increased (or didn't change) or decreased insignificantly
- [x] I have made corresponding changes to the documentation (where applicable)
- [x] I have grouped commits logically or I promise to squash my commits before merge
