### PR TITLE
[offline] Add bounding box to offline search settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - [Address Autofill, Place Autocomplete] Added new fields called `id` and `mapboxId` to `AddressAutofillResult` and `PlaceAutocompleteResult`
 - [Address Autofill, Place Autocomplete] Search is a two-steps action now, i.e. it returns `Suggestion`s (without the geo coordinate) at the first step and `Result` after suggestion selection. The `coordinate` field is no longer available in `Suggestion`.
 - [Address Autofill] `suggestions()` is renamed to `reverseGeocoding()`
+- [Offline search] Added bounding box filter for offline search functions
 
 ### Mapbox dependencies
 - Search Native SDK `2.0.0-alpha.13`

--- a/MapboxSearch/offline/api/api-metalava.txt
+++ b/MapboxSearch/offline/api/api-metalava.txt
@@ -157,13 +157,16 @@ package com.mapbox.search.offline {
   }
 
   @kotlinx.parcelize.Parcelize public final class OfflineSearchOptions implements android.os.Parcelable {
+    ctor public OfflineSearchOptions(com.mapbox.geojson.Point? proximity = null, Integer? limit = null, com.mapbox.geojson.Point? origin = null, com.mapbox.geojson.BoundingBox? boundingBox = null);
     ctor public OfflineSearchOptions(com.mapbox.geojson.Point? proximity = null, Integer? limit = null, com.mapbox.geojson.Point? origin = null);
     ctor public OfflineSearchOptions(com.mapbox.geojson.Point? proximity = null, Integer? limit = null);
     ctor public OfflineSearchOptions(com.mapbox.geojson.Point? proximity = null);
+    method public com.mapbox.geojson.BoundingBox? getBoundingBox();
     method public Integer? getLimit();
     method public com.mapbox.geojson.Point? getOrigin();
     method public com.mapbox.geojson.Point? getProximity();
     method public com.mapbox.search.offline.OfflineSearchOptions.Builder toBuilder();
+    property public final com.mapbox.geojson.BoundingBox? boundingBox;
     property public final Integer? limit;
     property public final com.mapbox.geojson.Point? origin;
     property public final com.mapbox.geojson.Point? proximity;
@@ -171,6 +174,7 @@ package com.mapbox.search.offline {
 
   public static final class OfflineSearchOptions.Builder {
     ctor public OfflineSearchOptions.Builder();
+    method public com.mapbox.search.offline.OfflineSearchOptions.Builder boundingBox(com.mapbox.geojson.BoundingBox boundingBox);
     method public com.mapbox.search.offline.OfflineSearchOptions build();
     method public com.mapbox.search.offline.OfflineSearchOptions.Builder limit(int limit);
     method public com.mapbox.search.offline.OfflineSearchOptions.Builder origin(com.mapbox.geojson.Point origin);

--- a/MapboxSearch/offline/api/offline.api
+++ b/MapboxSearch/offline/api/offline.api
@@ -205,9 +205,11 @@ public final class com/mapbox/search/offline/OfflineSearchOptions : android/os/P
 	public fun <init> (Lcom/mapbox/geojson/Point;)V
 	public fun <init> (Lcom/mapbox/geojson/Point;Ljava/lang/Integer;)V
 	public fun <init> (Lcom/mapbox/geojson/Point;Ljava/lang/Integer;Lcom/mapbox/geojson/Point;)V
-	public synthetic fun <init> (Lcom/mapbox/geojson/Point;Ljava/lang/Integer;Lcom/mapbox/geojson/Point;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Lcom/mapbox/geojson/Point;Ljava/lang/Integer;Lcom/mapbox/geojson/Point;Lcom/mapbox/geojson/BoundingBox;)V
+	public synthetic fun <init> (Lcom/mapbox/geojson/Point;Ljava/lang/Integer;Lcom/mapbox/geojson/Point;Lcom/mapbox/geojson/BoundingBox;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
+	public final fun getBoundingBox ()Lcom/mapbox/geojson/BoundingBox;
 	public final fun getLimit ()Ljava/lang/Integer;
 	public final fun getOrigin ()Lcom/mapbox/geojson/Point;
 	public final fun getProximity ()Lcom/mapbox/geojson/Point;
@@ -219,6 +221,7 @@ public final class com/mapbox/search/offline/OfflineSearchOptions : android/os/P
 
 public final class com/mapbox/search/offline/OfflineSearchOptions$Builder {
 	public fun <init> ()V
+	public final fun boundingBox (Lcom/mapbox/geojson/BoundingBox;)Lcom/mapbox/search/offline/OfflineSearchOptions$Builder;
 	public final fun build ()Lcom/mapbox/search/offline/OfflineSearchOptions;
 	public final fun limit (I)Lcom/mapbox/search/offline/OfflineSearchOptions$Builder;
 	public final fun origin (Lcom/mapbox/geojson/Point;)Lcom/mapbox/search/offline/OfflineSearchOptions$Builder;

--- a/MapboxSearch/offline/src/androidTest/java/com/mapbox/search/offline/OfflineSearchEngineIntegrationTest.kt
+++ b/MapboxSearch/offline/src/androidTest/java/com/mapbox/search/offline/OfflineSearchEngineIntegrationTest.kt
@@ -16,7 +16,6 @@ import com.mapbox.geojson.Geometry
 import com.mapbox.geojson.Point
 import com.mapbox.search.base.core.CoreResultType
 import com.mapbox.search.base.result.mapToBase
-import com.mapbox.search.base.utils.extension.mapToCore
 import com.mapbox.search.common.tests.FixedPointLocationEngine
 import com.mapbox.search.common.tests.createCoreSearchAddress
 import com.mapbox.search.common.tests.createCoreSearchAddressRegion
@@ -590,7 +589,7 @@ internal class OfflineSearchEngineIntegrationTest {
             )
 
             assertTrue(searchResult is SearchEngineResult.Results)
-            val results = searchResult.requireResults();
+            val results = searchResult.requireResults()
             assertTrue(results.isNotEmpty())
 
             for (res in results) {
@@ -615,14 +614,13 @@ internal class OfflineSearchEngineIntegrationTest {
         )
 
         assertTrue(searchResult is SearchEngineResult.Results)
-        val results = searchResult.requireResults();
+        val results = searchResult.requireResults()
         assertEquals("All points inside a bbox must be preserved", inside, results.size)
 
         for (res in results) {
             val p = res.coordinate
             assertTrue("Point(lon=${p.longitude()},lat=${p.latitude()}) must be in bbox `$bbox`", bbox.contains(p))
         }
-
     }
 
     private companion object {

--- a/MapboxSearch/offline/src/androidTest/java/com/mapbox/search/offline/OfflineSearchEngineIntegrationTest.kt
+++ b/MapboxSearch/offline/src/androidTest/java/com/mapbox/search/offline/OfflineSearchEngineIntegrationTest.kt
@@ -11,10 +11,12 @@ import com.mapbox.common.TileRegionLoadOptions
 import com.mapbox.common.TileRegionLoadProgress
 import com.mapbox.common.TileStore
 import com.mapbox.common.TileStoreObserver
+import com.mapbox.geojson.BoundingBox
 import com.mapbox.geojson.Geometry
 import com.mapbox.geojson.Point
 import com.mapbox.search.base.core.CoreResultType
 import com.mapbox.search.base.result.mapToBase
+import com.mapbox.search.base.utils.extension.mapToCore
 import com.mapbox.search.common.tests.FixedPointLocationEngine
 import com.mapbox.search.common.tests.createCoreSearchAddress
 import com.mapbox.search.common.tests.createCoreSearchAddressRegion
@@ -560,7 +562,67 @@ internal class OfflineSearchEngineIntegrationTest {
 
     @Test
     fun testBoundingBox() {
-        assertTrue(true)
+        loadOfflineData()
+
+        val lon = TEST_SEARCH_RESULT_MAPBOX.coordinate.longitude()
+        val lat = TEST_SEARCH_RESULT_MAPBOX.coordinate.latitude()
+
+        val bbox = BoundingBox.fromPoints(
+            Point.fromLngLat(
+                lon - 0.005,
+                lat - 0.005,
+            ),
+            Point.fromLngLat(
+                lon + 0.005,
+                lat + 0.005,
+            )
+        )
+
+        var inside = 0
+        var outside = 0
+
+        run {
+            val searchResult = searchEngine.searchBlocking(
+                TEST_QUERY,
+                OfflineSearchOptions(
+                    limit = 250,
+                ),
+            )
+
+            assertTrue(searchResult is SearchEngineResult.Results)
+            val results = searchResult.requireResults();
+            assertTrue(results.isNotEmpty())
+
+            for (res in results) {
+                if (bbox.contains(res.coordinate)) {
+                    inside++
+                } else {
+                    outside++
+                }
+            }
+
+            // We must have both inside and outside results to perform a test
+            assertTrue(inside > 0)
+            assertTrue(outside > 0)
+        }
+
+        val searchResult = searchEngine.searchBlocking(
+            TEST_QUERY,
+            OfflineSearchOptions(
+                limit = 250,
+                boundingBox = bbox
+            ),
+        )
+
+        assertTrue(searchResult is SearchEngineResult.Results)
+        val results = searchResult.requireResults();
+        assertEquals("All points inside a bbox must be preserved", inside, results.size)
+
+        for (res in results) {
+            val p = res.coordinate
+            assertTrue("Point(lon=${p.longitude()},lat=${p.latitude()}) must be in bbox `$bbox`", bbox.contains(p))
+        }
+
     }
 
     private companion object {
@@ -611,6 +673,12 @@ internal class OfflineSearchEngineIntegrationTest {
             if (distance1 == distance2) return true
             if (distance1 == null || distance2 == null) return false
             return abs(distance1 - distance2) < 10.0
+        }
+
+        fun BoundingBox.contains(p: Point): Boolean {
+            val lon = p.longitude()
+            val lat = p.latitude()
+            return west() < lon && lon < east() && south() < lat && lat < north()
         }
 
         fun assertSearchResultEquals(expected: OfflineSearchResult, actual: OfflineSearchResult): Boolean {

--- a/MapboxSearch/offline/src/main/java/com/mapbox/search/offline/OfflineSearchEngineImpl.kt
+++ b/MapboxSearch/offline/src/main/java/com/mapbox/search/offline/OfflineSearchEngineImpl.kt
@@ -112,10 +112,19 @@ internal class OfflineSearchEngineImpl(
         callback: OfflineSearchCallback
     ): AsyncOperationTask {
         activityReporter.reportActivity("offline-search-engine-search-nearby-street")
-
-        if (radiusMeters < 0.0) {
+        if (radiusMeters <= 0.0) {
             executor.execute {
-                callback.onError(IllegalArgumentException("Negative radius"))
+                callback.onError(IllegalArgumentException("Negative or zero radius: $radiusMeters"))
+            }
+            return AsyncOperationTaskImpl.COMPLETED
+        }
+
+        val lon = proximity.longitude()
+        val lat = proximity.latitude()
+        if (lon <= -180.0 || lon >= 180.0 ||
+            lat <= -90.0 || lat >= 90.0) {
+            executor.execute {
+                callback.onError(IllegalArgumentException("Invalid proximity(lon=$lon,lat=$lat)"))
             }
             return AsyncOperationTaskImpl.COMPLETED
         }

--- a/MapboxSearch/offline/src/main/java/com/mapbox/search/offline/OfflineSearchOptions.kt
+++ b/MapboxSearch/offline/src/main/java/com/mapbox/search/offline/OfflineSearchOptions.kt
@@ -1,8 +1,10 @@
 package com.mapbox.search.offline
 
 import android.os.Parcelable
+import com.mapbox.geojson.BoundingBox
 import com.mapbox.geojson.Point
 import com.mapbox.search.base.core.CoreSearchOptions
+import com.mapbox.search.base.utils.extension.mapToCore
 import kotlinx.parcelize.Parcelize
 
 /**
@@ -27,6 +29,13 @@ public class OfflineSearchOptions @JvmOverloads public constructor(
      * @see [OfflineSearchResult.distanceMeters]
      */
     public val origin: Point? = null,
+
+    /**
+     * Limit results to only those contained within the supplied bounding box.
+     * The bounding box cannot cross the 180th meridian (longitude +/-180.0 deg.)
+     * and North or South pole (latitude +/- 90.0 deg.).
+     */
+    public val boundingBox: BoundingBox? = null,
 ) : Parcelable {
 
     init {
@@ -52,6 +61,7 @@ public class OfflineSearchOptions @JvmOverloads public constructor(
         if (proximity != other.proximity) return false
         if (limit != other.limit) return false
         if (origin != other.origin) return false
+        if (boundingBox != other.boundingBox) return false
 
         return true
     }
@@ -63,6 +73,7 @@ public class OfflineSearchOptions @JvmOverloads public constructor(
         var result = proximity?.hashCode() ?: 0
         result = 31 * result + (limit ?: 0)
         result = 31 * result + (origin?.hashCode() ?: 0)
+        result = 31 * result + (boundingBox?.hashCode() ?: 0)
         return result
     }
 
@@ -70,7 +81,9 @@ public class OfflineSearchOptions @JvmOverloads public constructor(
      * @suppress
      */
     override fun toString(): String {
-        return "OfflineSearchOptions(proximity=$proximity, limit=$limit, origin=$origin)"
+        return "OfflineSearchOptions(" +
+                "proximity=$proximity, limit=$limit, origin=$origin, boundingBox=$boundingBox" +
+                ")"
     }
 
     /**
@@ -81,11 +94,13 @@ public class OfflineSearchOptions @JvmOverloads public constructor(
         private var proximity: Point? = null
         private var limit: Int? = null
         private var origin: Point? = null
+        private var boundingBox: BoundingBox? = null
 
         internal constructor(options: OfflineSearchOptions) : this() {
             proximity = options.proximity
             limit = options.limit
             origin = options.origin
+            boundingBox = options.boundingBox
         }
 
         /**
@@ -104,12 +119,18 @@ public class OfflineSearchOptions @JvmOverloads public constructor(
         public fun origin(origin: Point): Builder = apply { this.origin = origin }
 
         /**
+         * Limit results to only those contained within the supplied bounding box.
+         */
+        public fun boundingBox(boundingBox: BoundingBox): Builder = apply { this.boundingBox = boundingBox }
+
+        /**
          * Create [OfflineSearchOptions] instance from builder data.
          */
         public fun build(): OfflineSearchOptions = OfflineSearchOptions(
             proximity = proximity,
             limit = limit,
             origin = origin,
+            boundingBox = boundingBox,
         )
     }
 }
@@ -120,7 +141,7 @@ internal fun OfflineSearchOptions.mapToCore(): CoreSearchOptions = CoreSearchOpt
     origin,
     null,
     null,
-    null,
+    boundingBox?.mapToCore(),
     null,
     null,
     null,

--- a/MapboxSearch/offline/src/test/java/com/mapbox/search/offline/OfflineSearchOptionsTest.kt
+++ b/MapboxSearch/offline/src/test/java/com/mapbox/search/offline/OfflineSearchOptionsTest.kt
@@ -1,6 +1,8 @@
 package com.mapbox.search.offline
 
+import com.mapbox.geojson.BoundingBox
 import com.mapbox.geojson.Point
+import com.mapbox.search.base.utils.extension.mapToCore
 import com.mapbox.search.common.tests.CommonSdkTypeObjectCreators
 import com.mapbox.search.common.tests.ReflectionObjectsFactory
 import com.mapbox.search.common.tests.ToStringVerifier
@@ -47,6 +49,7 @@ internal class OfflineSearchOptionsTest {
                     proximity = null,
                     limit = null,
                     origin = null,
+                    boundingBox = null,
                 )
 
                 Then("Options should be equal", expectedOptions, actualOptions)
@@ -63,12 +66,14 @@ internal class OfflineSearchOptionsTest {
                     .proximity(TEST_POINT)
                     .limit(100)
                     .origin(TEST_ORIGIN_POINT)
+                    .boundingBox(TEST_BOUNDING_BOX)
                     .build()
 
                 val expectedOptions = OfflineSearchOptions(
                     proximity = TEST_POINT,
                     limit = 100,
                     origin = TEST_ORIGIN_POINT,
+                    boundingBox = TEST_BOUNDING_BOX,
                 )
 
                 Then("Options should be equal", expectedOptions, actualOptions)
@@ -95,12 +100,14 @@ internal class OfflineSearchOptionsTest {
                     proximity = TEST_POINT,
                     limit = 100,
                     origin = TEST_ORIGIN_POINT,
+                    boundingBox = TEST_BOUNDING_BOX,
                 ).mapToCore()
 
                 val expectedOptions = createTestCoreSearchOptions(
                     proximity = TEST_POINT,
                     limit = 100,
                     origin = TEST_ORIGIN_POINT,
+                    bbox = TEST_BOUNDING_BOX.mapToCore(),
                 )
 
                 Then("Options should be equal", expectedOptions, actualOptions)
@@ -116,6 +123,7 @@ internal class OfflineSearchOptionsTest {
                     proximity = TEST_POINT,
                     limit = 100,
                     origin = TEST_ORIGIN_POINT,
+                    boundingBox = TEST_BOUNDING_BOX,
                 )
 
                 Then("Options should be equal", options, options.toBuilder().build())
@@ -160,5 +168,6 @@ internal class OfflineSearchOptionsTest {
     private companion object {
         val TEST_POINT: Point = Point.fromLngLat(10.0, 10.0)
         val TEST_ORIGIN_POINT: Point = Point.fromLngLat(20.0, 20.0)
+        val TEST_BOUNDING_BOX: BoundingBox = BoundingBox.fromLngLats(0.0, 0.0, 90.0, 45.0)
     }
 }

--- a/MapboxSearch/sdk/src/main/java/com/mapbox/search/SearchOptions.kt
+++ b/MapboxSearch/sdk/src/main/java/com/mapbox/search/SearchOptions.kt
@@ -30,7 +30,8 @@ public class SearchOptions @JvmOverloads public constructor(
 
     /**
      * Limit results to only those contained within the supplied bounding box.
-     * The bounding box cannot cross the 180th meridian.
+     * The bounding box cannot cross the 180th meridian (longitude +/-180.0 deg.)
+     * and North or South pole (latitude +/- 90.0 deg.).
      */
     public val boundingBox: BoundingBox? = null,
 

--- a/MapboxSearch/ui/src/main/java/com/mapbox/search/ui/adapter/engines/SearchEngineUiAdapter.kt
+++ b/MapboxSearch/ui/src/main/java/com/mapbox/search/ui/adapter/engines/SearchEngineUiAdapter.kt
@@ -689,6 +689,7 @@ public class SearchEngineUiAdapter(
             proximity = proximity,
             origin = origin,
             limit = limit,
+            boundingBox = boundingBox,
         )
     }
 }


### PR DESCRIPTION
### Description
Add bounding box to `OfflineSearch`
Original discussion: https://github.com/mapbox/mapbox-search-sdk-v2/pull/12#issuecomment-1914433651


### Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have updated the `CHANGELOG` including this PR (where applicable)
- [x] I have run tests and automatic checks locally
- [ ] I have run `pitest` check locally and checked that the coverage increased (or didn't change) or decreased insignificantly
- [x] I have made corresponding changes to the documentation (where applicable)
- [x] I have grouped commits logically or I promise to squash my commits before merge
