### PR TITLE
Introduce the timeout for location updates

### DIFF
--- a/DemoApps/SearchWithMaps/app/build.gradle
+++ b/DemoApps/SearchWithMaps/app/build.gradle
@@ -40,7 +40,7 @@ android {
 }
 
 dependencies {
-    implementation "com.mapbox.search:mapbox-search-android-ui:2.0.0-beta.2"
+    implementation "com.mapbox.search:mapbox-search-android-ui:2.0.0-location-updates-timeout-200ms"
     implementation "com.mapbox.maps:android:11.0.0"
 
     implementation 'androidx.core:core-ktx:1.6.0'

--- a/MapboxSearch/base/src/main/java/com/mapbox/search/base/location/LocationEngineAdapter.kt
+++ b/MapboxSearch/base/src/main/java/com/mapbox/search/base/location/LocationEngineAdapter.kt
@@ -14,6 +14,18 @@ import com.mapbox.search.base.utils.LocalTimeProvider
 import com.mapbox.search.base.utils.TimeProvider
 import com.mapbox.search.base.utils.extension.toPoint
 import com.mapbox.search.internal.bindgen.LonLatBBox
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+
+// Maximum time period for waiting for location updates (in milliseconds)
+private var locationEngineObservationTimeout: Long? = 200L
+
+@Suppress("UNUSED")
+fun setLocationEngineLocationObservationTimeout(timeout: Long?) {
+    locationEngineObservationTimeout = timeout
+}
 
 // Suppressed because we check permission but lint can't detekt it
 @SuppressLint("MissingPermission")
@@ -23,11 +35,13 @@ class LocationEngineAdapter(
     private val timeProvider: TimeProvider = LocalTimeProvider(),
     private val locationPermissionChecker: (Application) -> Boolean = {
         PermissionsManager.areLocationPermissionsGranted(app)
-    }
+    },
 ) : CoreLocationProvider {
 
     @Volatile
     private var lastLocationInfo = LocationInfo(null, 0)
+
+    private var timeoutWatcherJob: Job? = null
 
     private val locationObserver = LocationObserver { locations ->
         locations.firstOrNull()?.let {
@@ -54,11 +68,21 @@ class LocationEngineAdapter(
 
     private fun startLocationListener() {
         locationProvider?.addLocationObserver(locationObserver)
+
+        locationEngineObservationTimeout?.let { timeout ->
+            timeoutWatcherJob?.cancel()
+            timeoutWatcherJob = CoroutineScope(Job()).launch {
+                delay(timeout)
+                timeoutWatcherJob = null
+                stopLocationListener()
+            }
+        }
     }
 
     private fun stopLocationListener() {
         locationProvider?.removeLocationObserver(locationObserver)
         locationCancelable?.cancel()
+        timeoutWatcherJob?.cancel()
     }
 
     override fun getLocation(): Point? {

--- a/MapboxSearch/gradle.properties
+++ b/MapboxSearch/gradle.properties
@@ -21,7 +21,7 @@ android.enableJetifier=false
 kotlin.code.style=official
 
 # SDK version attributes
-VERSION_NAME=2.0.0-beta.4
+VERSION_NAME=2.0.0-location-updates-timeout-200ms
 
 # Artifact attributes
 mapboxArtifactUserOrg=mapbox


### PR DESCRIPTION
Set locationObservationTimeout in milliseconds or `null` to turn the timer off

<!-- ⚠️ TEMPLATE ⚠️ -->
<!-- Template for GitHub PR descriptions. Use it as a guide on how to describe your work. Feel free to remove any section when you're opening a PR if you think it does not apply for your committed changes. -->

### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->


### Screenshots or Gifs
<!-- 
Include media files to provide additional context. It's REALLY useful for UI related PRs (e.g. ![screenshot gif](link))

Please note that you can change image width/height with one of the following ways:
- For specifying size in percentage:
<img src="https://user-images.githubusercontent.com/4005589/120349671-f86c4f80-c306-11eb-8c71-b903666c2bc.png" width=50% height=50%>
- For specifying size in pixels:
<img src="https://user-images.githubusercontent.com/4005589/120349671-f86c4f80-c306-11eb-8c71-b903666c2bc.png" width="200" height="200">
-->


### Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR (where applicable)
- [ ] I have run tests and automatic checks locally
- [ ] I have run `pitest` check locally and checked that the coverage increased (or didn't change) or decreased insignificantly
- [ ] I have made corresponding changes to the documentation (where applicable)
- [ ] I have grouped commits logically or I promise to squash my commits before merge
