### PR TITLE
fix(ui): Recent searches not showing as favorites

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog for the Mapbox Search SDK for Android
 
+## 2.2.1
+
+### Bug fixes
+- Fixes [#197](https://github.com/mapbox/mapbox-search-android/issues/197) clicking a "Recent Search" that is a favorite doesn't show as a favorite in the `SearchPlaceBottomSheetView`
+
+
 ## 2.2.0
 
 

--- a/MapboxSearch/ui/src/main/java/com/mapbox/search/ui/view/place/SearchPlaceBottomSheetView.kt
+++ b/MapboxSearch/ui/src/main/java/com/mapbox/search/ui/view/place/SearchPlaceBottomSheetView.kt
@@ -270,47 +270,69 @@ public class SearchPlaceBottomSheetView @JvmOverloads constructor(
     private fun populateFavoriteButtonInfo(
         searchPlace: SearchPlace,
         overriddenAddedToFavorite: Boolean = searchPlace.record is FavoriteRecord,
-        animate: Boolean = false,
+        animate: Boolean = true,
         onFavoriteAdded: ((FavoriteRecord) -> Unit)? = null
     ) {
+        val populateButton = { text: Int, icon: Int, listener: OnClickListener? ->
+            favoriteButton.setText(text, animate)
+            favoriteButton.setIcon(icon, animate)
+            favoriteButton.setOnClickListener(listener)
+        }
+
         if (overriddenAddedToFavorite) {
-            Triple(
+            populateButton(
                 R.string.mapbox_search_sdk_place_card_added_to_favorites,
                 R.drawable.mapbox_search_sdk_ic_added_to_favorites,
                 null
             )
         } else {
-            val listener: (View) -> Unit = {
-                if (addFavoriteTask == null || addFavoriteTask?.isCancelled == true) {
-                    val newFavorite = searchPlace.toUserFavorite()
-                    addFavoriteTask = favoritesDataProvider.upsert(
-                        newFavorite,
-                        object : CompletionCallback<Unit> {
-                            override fun onComplete(result: Unit) {
-                                onFavoriteAdded?.invoke(newFavorite)
-                                onSearchPlaceAddedToFavoritesListeners.forEach {
-                                    it.onSearchPlaceAddedToFavorites(searchPlace, newFavorite)
-                                }
-                            }
+            favoritesDataProvider.get(searchPlace.id, object : CompletionCallback<FavoriteRecord?> {
+                override fun onComplete(result: FavoriteRecord?) {
+                    if (result != null) {
+                        populateButton(
+                            R.string.mapbox_search_sdk_place_card_added_to_favorites,
+                            R.drawable.mapbox_search_sdk_ic_added_to_favorites,
+                            null
+                        )
+                    } else {
+                        val listener: (View) -> Unit = {
+                            if (addFavoriteTask == null || addFavoriteTask?.isCancelled == true) {
+                                val newFavorite = searchPlace.toUserFavorite()
+                                addFavoriteTask = favoritesDataProvider.upsert(
+                                    newFavorite,
+                                    object : CompletionCallback<Unit> {
+                                        override fun onComplete(result: Unit) {
+                                            onFavoriteAdded?.invoke(newFavorite)
+                                            onSearchPlaceAddedToFavoritesListeners.forEach {
+                                                it.onSearchPlaceAddedToFavorites(searchPlace, newFavorite)
+                                            }
+                                        }
 
-                            override fun onError(e: Exception) {
-                                // Shouldn't happen with favorites
-                                throwDebug(e) {
-                                    "Unable to add favorite: ${e.message}"
-                                }
+                                        override fun onError(e: Exception) {
+                                            // Shouldn't happen with favorites
+                                            throwDebug(e) {
+                                                "Unable to add favorite: ${e.message}"
+                                            }
+                                        }
+                                    })
                             }
-                        })
+                        }
+
+                        populateButton(
+                            R.string.mapbox_search_sdk_place_card_add_to_favorites,
+                            R.drawable.mapbox_search_sdk_ic_add_favorite,
+                            listener
+                        )
+                    }
                 }
-            }
-            Triple(
-                R.string.mapbox_search_sdk_place_card_add_to_favorites,
-                R.drawable.mapbox_search_sdk_ic_add_favorite,
-                listener
-            )
-        }.let { (text, icon, onClickListener) ->
-            favoriteButton.setText(text, animate)
-            favoriteButton.setIcon(icon, animate)
-            favoriteButton.setOnClickListener(onClickListener)
+
+                override fun onError(e: Exception) {
+                    // should not happen
+                    throwDebug(e) {
+                        "Unable to determine if favorite: ${e.message}"
+                    }
+                }
+            })
         }
     }
 

--- a/MapboxSearch/ui/src/main/java/com/mapbox/search/ui/view/place/SearchPlaceBottomSheetView.kt
+++ b/MapboxSearch/ui/src/main/java/com/mapbox/search/ui/view/place/SearchPlaceBottomSheetView.kt
@@ -270,7 +270,7 @@ public class SearchPlaceBottomSheetView @JvmOverloads constructor(
     private fun populateFavoriteButtonInfo(
         searchPlace: SearchPlace,
         overriddenAddedToFavorite: Boolean = searchPlace.record is FavoriteRecord,
-        animate: Boolean = true,
+        animate: Boolean = false,
         onFavoriteAdded: ((FavoriteRecord) -> Unit)? = null
     ) {
         val populateButton = { text: Int, icon: Int, listener: OnClickListener? ->


### PR DESCRIPTION
<!-- ⚠️ TEMPLATE ⚠️ -->
<!-- Template for GitHub PR descriptions. Use it as a guide on how to describe your work. Feel free to remove any section when you're opening a PR if you think it does not apply for your committed changes. -->

### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->
Fixes issue #197. Clicking on a "Recent search" that happens to be a favorite did not display as a favorite in the `SearchPlaceBottomSheetView`. This change uses the `FavoriteDataProvider` to check if the item is a favorite when the view loads.

### Screenshots or Gifs
<!-- 
Include media files to provide additional context. It's REALLY useful for UI related PRs (e.g. ![screenshot gif](link))

Please note that you can change image width/height with one of the following ways:
- For specifying size in percentage:
<img src="https://user-images.githubusercontent.com/4005589/120349671-f86c4f80-c306-11eb-8c71-b903666c2bc.png" width=50% height=50%>
- For specifying size in pixels:
<img src="https://user-images.githubusercontent.com/4005589/120349671-f86c4f80-c306-11eb-8c71-b903666c2bc.png" width="200" height="200">
-->

**Old Behavior**
[Old Favorites Behavior.webm](https://github.com/mapbox/mapbox-search-android/assets/388411/5ebcf22b-0e1d-4d9d-afd6-33213aceb0e8)

**New Behavior**
[New Favorites Behavior.webm](https://github.com/mapbox/mapbox-search-android/assets/388411/a86e4cf2-4021-4366-a383-7ed3e6e793af)

### Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have updated the `CHANGELOG` including this PR (where applicable)
- [x] I have run tests and automatic checks locally
- [x] I have run `pitest` check locally and checked that the coverage increased (or didn't change) or decreased insignificantly
- [x] I have made corresponding changes to the documentation (where applicable)
- [x] I have grouped commits logically or I promise to squash my commits before merge
