### PR TITLE
Adding Debouncing to Sample Application

### DIFF
--- a/MapboxSearch/sample/src/main/java/com/mapbox/search/sample/MainActivity.kt
+++ b/MapboxSearch/sample/src/main/java/com/mapbox/search/sample/MainActivity.kt
@@ -81,12 +81,14 @@ import com.mapbox.search.ui.view.SearchMode
 import com.mapbox.search.ui.view.SearchResultsView
 import com.mapbox.search.ui.view.place.SearchPlace
 import com.mapbox.search.ui.view.place.SearchPlaceBottomSheetView
+import com.mapbox.turf.TurfConstants
+import com.mapbox.turf.TurfTransformation
 
 class MainActivity : AppCompatActivity() {
 
     private val locationProvider: LocationProvider? = defaultLocationProvider()
 
-    private val debouncer = Debouncer(300L);
+    private val debouncer = Debouncer(300L)
 
     private lateinit var toolbar: Toolbar
     private lateinit var searchView: SearchView

--- a/MapboxSearch/sample/src/main/java/com/mapbox/search/sample/MainActivity.kt
+++ b/MapboxSearch/sample/src/main/java/com/mapbox/search/sample/MainActivity.kt
@@ -81,8 +81,6 @@ import com.mapbox.search.ui.view.SearchMode
 import com.mapbox.search.ui.view.SearchResultsView
 import com.mapbox.search.ui.view.place.SearchPlace
 import com.mapbox.search.ui.view.place.SearchPlaceBottomSheetView
-import com.mapbox.turf.TurfConstants
-import com.mapbox.turf.TurfTransformation
 
 class MainActivity : AppCompatActivity() {
 

--- a/MapboxSearch/sample/src/main/java/com/mapbox/search/sample/MainActivity.kt
+++ b/MapboxSearch/sample/src/main/java/com/mapbox/search/sample/MainActivity.kt
@@ -74,6 +74,7 @@ import com.mapbox.search.sample.api.PlaceAutocompleteKotlinExampleActivity
 import com.mapbox.search.sample.api.ReverseGeocodingJavaExampleActivity
 import com.mapbox.search.sample.api.ReverseGeocodingKotlinExampleActivity
 import com.mapbox.search.ui.adapter.engines.SearchEngineUiAdapter
+import com.mapbox.search.ui.utils.Debouncer
 import com.mapbox.search.ui.view.CommonSearchViewConfiguration
 import com.mapbox.search.ui.view.DistanceUnitType
 import com.mapbox.search.ui.view.SearchMode
@@ -84,6 +85,8 @@ import com.mapbox.search.ui.view.place.SearchPlaceBottomSheetView
 class MainActivity : AppCompatActivity() {
 
     private val locationProvider: LocationProvider? = defaultLocationProvider()
+
+    private val debouncer = Debouncer(300L);
 
     private lateinit var toolbar: Toolbar
     private lateinit var searchView: SearchView
@@ -362,7 +365,9 @@ class MainActivity : AppCompatActivity() {
             }
 
             override fun onQueryTextChange(newText: String): Boolean {
-                searchEngineUiAdapter.search(newText)
+                debouncer.debounce {
+                    searchEngineUiAdapter.search(newText)
+                }
                 return false
             }
         })

--- a/MapboxSearch/ui/api/api-metalava.txt
+++ b/MapboxSearch/ui/api/api-metalava.txt
@@ -77,6 +77,12 @@ package com.mapbox.search.ui.adapter.location {
 
 package com.mapbox.search.ui.utils {
 
+  public final class Debouncer {
+    ctor public Debouncer(long delayMillis);
+    method public void cancel();
+    method public void debounce(kotlin.jvm.functions.Function0<kotlin.Unit> action);
+  }
+
   public final class ThemePatcherKt {
   }
 

--- a/MapboxSearch/ui/api/ui.api
+++ b/MapboxSearch/ui/api/ui.api
@@ -68,6 +68,12 @@ public final class com/mapbox/search/ui/adapter/location/LocationObservationTime
 	public static final fun setLocationObservationTimeout (Ljava/lang/Long;)V
 }
 
+public final class com/mapbox/search/ui/utils/Debouncer {
+	public fun <init> (J)V
+	public final fun cancel ()V
+	public final fun debounce (Lkotlin/jvm/functions/Function0;)V
+}
+
 public final class com/mapbox/search/ui/view/CommonSearchViewConfiguration : android/os/Parcelable {
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public fun <init> ()V

--- a/MapboxSearch/ui/build.gradle
+++ b/MapboxSearch/ui/build.gradle
@@ -95,6 +95,7 @@ dependencies {
     testImplementation "org.junit.jupiter:junit-jupiter-api:$junit_5_version"
     testImplementation "org.junit.jupiter:junit-jupiter-engine:$junit_5_version"
     testImplementation "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
+    testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:$kotlin_coroutines_version"
 
     androidTestImplementation project(":common-tests")
     androidTestImplementation "androidx.test:runner:$androidx_test_runner_version"

--- a/MapboxSearch/ui/src/main/java/com/mapbox/search/ui/utils/Debouncer.kt
+++ b/MapboxSearch/ui/src/main/java/com/mapbox/search/ui/utils/Debouncer.kt
@@ -1,0 +1,34 @@
+package com.mapbox.search.ui.utils
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+
+/**
+ * Simple helper class for debouncing main thread requests. All actions are executed
+ * using [Dispatchers.Main].
+ */
+public class Debouncer(private val delayMillis: Long) {
+    private var job: Job? = null
+
+    /**
+     * Takes an action that should be "debounced"
+     * @param action to be debounced
+     */
+    public fun debounce(action: () -> Unit) {
+        job?.cancel()
+        job = CoroutineScope(Dispatchers.Main).launch {
+            delay(delayMillis)
+            action()
+        }
+    }
+
+    /**
+     * Cancels the currently running action.
+     */
+    public fun cancel() {
+        job?.cancel()
+    }
+}

--- a/MapboxSearch/ui/src/test/java/com/mapbox/search/ui/utils/DebouncerTest.kt
+++ b/MapboxSearch/ui/src/test/java/com/mapbox/search/ui/utils/DebouncerTest.kt
@@ -1,0 +1,78 @@
+package com.mapbox.search.ui.utils
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.never
+import org.mockito.Mockito.times
+import org.mockito.Mockito.verify
+
+@OptIn(ExperimentalCoroutinesApi::class)
+internal class DebouncerTest {
+
+    private val testDispatcher = StandardTestDispatcher()
+
+    @BeforeEach
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+    }
+
+    @AfterEach
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun `Test action executes after specified time`() = runTest {
+        val action = mock(Runnable::class.java)
+        val debouncer = Debouncer(500L)
+
+        debouncer.debounce { action.run() }
+        advanceTimeBy(499L)
+        runCurrent()
+
+        verify(action, never()).run()
+
+        advanceTimeBy(1L)
+        runCurrent()
+
+        verify(action, times(1)).run()
+    }
+
+    @Test
+    fun `Test previous action is cancelled and never fires`() = runTest {
+        val action1 = mock(Runnable::class.java)
+        val action2 = mock(Runnable::class.java)
+        val debouncer = Debouncer(500L)
+
+        // start the first action
+        debouncer.debounce { action1.run() }
+        advanceTimeBy(300L)
+
+        // trigger the second which should cancel the first
+        debouncer.debounce { action2.run() }
+        advanceTimeBy(200L)
+
+        // run all currently triggered
+        runCurrent()
+
+        // verify nothing ran
+        verify(action1, never()).run()
+        verify(action2, never()).run()
+
+        // move forward so the second action runs
+        advanceTimeBy(300L)
+        runCurrent()
+
+        verify(action2, times(1)).run()
+    }
+}


### PR DESCRIPTION
<!-- ⚠️ TEMPLATE ⚠️ -->
<!-- Template for GitHub PR descriptions. Use it as a guide on how to describe your work. Feel free to remove any section when you're opening a PR if you think it does not apply for your committed changes. -->

### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->
Adds basic debouncing to our main sample search application. This really has a dramatic difference in performance for offline search. Before this change, when a user typed "coffee," a request was fired for each keystroke, dramatically slowing the offline engine.

### Screenshots or Gifs
<!-- 
Include media files to provide additional context. It's REALLY useful for UI related PRs (e.g. ![screenshot gif](link))

Please note that you can change image width/height with one of the following ways:
- For specifying size in percentage:
<img src="https://user-images.githubusercontent.com/4005589/120349671-f86c4f80-c306-11eb-8c71-b903666c2bc.png" width=50% height=50%>
- For specifying size in pixels:
<img src="https://user-images.githubusercontent.com/4005589/120349671-f86c4f80-c306-11eb-8c71-b903666c2bc.png" width="200" height="200">
-->
#### No Debounce
![No Debounce](https://github.com/mapbox/mapbox-search-android/assets/388411/6affd2ab-d59c-4f6f-8758-a8f7f9ff1d1d)

#### With Debounce
![With Debounce](https://github.com/mapbox/mapbox-search-android/assets/388411/7f037e67-96c1-4698-a201-40f1b9dcc8ce)

### Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have updated the `CHANGELOG` including this PR (where applicable)
- [x] I have run tests and automatic checks locally
- [x] I have run `pitest` check locally and checked that the coverage increased (or didn't change) or decreased insignificantly
- [x] I have made corresponding changes to the documentation (where applicable)
- [x] I have grouped commits logically or I promise to squash my commits before merge
