### PR TITLE
feat(online): aligning search options with search native v2.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 2.4.0-rc.3
 
-### Bug fixes
+### New features
 - Aligning `SearchOptions` to Search Native SDK
 - Adding `List<AttributeSet>` to `SelectOptions` to support retrieving distinct attribute sets on SEARCH_BOX retrieve calls
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog for the Mapbox Search SDK for Android
 
+## 2.4.0-rc.3
+
+### Bug fixes
+- Aligning `SearchOptions` to Search Native SDK
+- Adding `List<AttributeSet>` to `SelectOptions` to support retrieving distinct attribute sets on SEARCH_BOX retrieve calls
+
+### Mapbox dependencies
+- Search Native SDK `2.3.0-rc.6`
+- Common SDK `v24.6.0`
+
 ## 2.4.0-rc.2
 
 ### Bug fixes

--- a/MapboxSearch/base/src/main/java/com/mapbox/search/base/core/CoreAliases.kt
+++ b/MapboxSearch/base/src/main/java/com/mapbox/search/base/core/CoreAliases.kt
@@ -35,3 +35,4 @@ typealias CoreSearchResponseError = com.mapbox.search.internal.bindgen.Error
 typealias CoreSearchResponseErrorType = com.mapbox.search.internal.bindgen.Error.Type
 typealias CoreChildMetadata = com.mapbox.search.internal.bindgen.ResultChildMetadata
 typealias CoreAttributeSet = com.mapbox.search.internal.bindgen.AttributeSet
+typealias CoreRetrieveOptions = com.mapbox.search.internal.bindgen.RetrieveOptions

--- a/MapboxSearch/base/src/main/java/com/mapbox/search/base/core/CoreFactoryFunctions.kt
+++ b/MapboxSearch/base/src/main/java/com/mapbox/search/base/core/CoreFactoryFunctions.kt
@@ -1,7 +1,6 @@
 package com.mapbox.search.base.core
 
 import com.mapbox.geojson.Point
-import com.mapbox.search.internal.bindgen.AttributeSet
 import com.mapbox.search.internal.bindgen.LonLatBBox
 import com.mapbox.search.internal.bindgen.QueryType
 import com.mapbox.search.internal.bindgen.ReverseGeoOptions
@@ -25,7 +24,6 @@ fun createCoreSearchOptions(
     route: List<Point>? = null,
     sarType: String? = null,
     timeDeviation: Double? = null,
-    attributeSets: List<AttributeSet>? = null,
     addonAPI: Map<String, String>? = null,
 ): CoreSearchOptions = CoreSearchOptions(
     proximity,

--- a/MapboxSearch/base/src/main/java/com/mapbox/search/base/core/CoreFactoryFunctions.kt
+++ b/MapboxSearch/base/src/main/java/com/mapbox/search/base/core/CoreFactoryFunctions.kt
@@ -44,8 +44,7 @@ fun createCoreSearchOptions(
     route,
     sarType,
     timeDeviation,
-    addonAPI?.let { it as? HashMap<String, String> ?: HashMap(it) },
-    attributeSets
+    addonAPI?.let { it as? HashMap<String, String> ?: HashMap(it) }
 )
 
 fun createCoreReverseGeoOptions(

--- a/MapboxSearch/common-tests/src/main/java/com/mapbox/search/common/tests/CoreTestDataFactory.kt
+++ b/MapboxSearch/common-tests/src/main/java/com/mapbox/search/common/tests/CoreTestDataFactory.kt
@@ -66,8 +66,7 @@ fun createTestCoreSearchOptions(
     route,
     sarType,
     timeDeviation,
-    addonAPI?.let { it as? HashMap<String, String> ?: HashMap(it) },
-    attributeSets
+    addonAPI?.let { it as? HashMap<String, String> ?: HashMap(it) }
 )
 
 @Suppress("LongParameterList")

--- a/MapboxSearch/common-tests/src/main/java/com/mapbox/search/common/tests/CoreTestDataFactory.kt
+++ b/MapboxSearch/common-tests/src/main/java/com/mapbox/search/common/tests/CoreTestDataFactory.kt
@@ -2,7 +2,6 @@ package com.mapbox.search.common.tests
 
 import com.mapbox.bindgen.ExpectedFactory
 import com.mapbox.geojson.Point
-import com.mapbox.search.internal.bindgen.AttributeSet
 import com.mapbox.search.internal.bindgen.ConnectionError
 import com.mapbox.search.internal.bindgen.HttpError
 import com.mapbox.search.internal.bindgen.ImageInfo
@@ -48,7 +47,6 @@ fun createTestCoreSearchOptions(
     sarType: String? = null,
     timeDeviation: Double? = null,
     addonAPI: Map<String, String>? = null,
-    attributeSets: List<AttributeSet>? = null,
 ): SearchOptions = SearchOptions(
     proximity,
     origin,

--- a/MapboxSearch/gradle.properties
+++ b/MapboxSearch/gradle.properties
@@ -21,7 +21,7 @@ android.enableJetifier=false
 kotlin.code.style=official
 
 # SDK version attributes
-VERSION_NAME=2.4.0-rc.2
+VERSION_NAME=2.4.0-rc.3
 
 # Artifact attributes
 mapboxArtifactUserOrg=mapbox

--- a/MapboxSearch/gradle/versions.gradle
+++ b/MapboxSearch/gradle/versions.gradle
@@ -43,10 +43,10 @@ ext {
 
     mapbox_maps_version = '11.0.0'
 
-    common_sdk_version = '24.6.0-rc.1'
+    common_sdk_version = '24.6.0'
     mapbox_base_version = '0.8.0'
 
-    search_native_version = '2.3.0-rc.4'
+    search_native_version = '2.3.0-rc.6'
 
     detekt_version = '1.19.0'
 

--- a/MapboxSearch/gradle/versions.gradle
+++ b/MapboxSearch/gradle/versions.gradle
@@ -46,7 +46,7 @@ ext {
     common_sdk_version = '24.6.0'
     mapbox_base_version = '0.8.0'
 
-    search_native_version = '2.3.0-rc.6'
+    search_native_version = '2.3.0'
 
     detekt_version = '1.19.0'
 

--- a/MapboxSearch/offline/src/main/java/com/mapbox/search/offline/OfflineSearchOptions.kt
+++ b/MapboxSearch/offline/src/main/java/com/mapbox/search/offline/OfflineSearchOptions.kt
@@ -147,7 +147,7 @@ internal fun OfflineSearchOptions.mapToCore(): CoreSearchOptions = CoreSearchOpt
     null,
     limit,
     null,
-    null,
+    false,
     null,
     null,
     null,

--- a/MapboxSearch/sdk/api/api-metalava.txt
+++ b/MapboxSearch/sdk/api/api-metalava.txt
@@ -312,7 +312,6 @@ package com.mapbox.search {
   }
 
   @kotlinx.parcelize.Parcelize public final class SearchOptions implements android.os.Parcelable {
-    ctor public SearchOptions(com.mapbox.geojson.Point? proximity = null, com.mapbox.geojson.BoundingBox? boundingBox = null, java.util.List<com.mapbox.search.common.IsoCountryCode>? countries = null, Boolean? fuzzyMatch = null, java.util.List<com.mapbox.search.common.IsoLanguageCode>? languages = defaultSearchOptionsLanguage(), Integer? limit = null, java.util.List<? extends com.mapbox.search.QueryType>? types = null, Integer? requestDebounce = null, com.mapbox.geojson.Point? origin = null, com.mapbox.search.SearchNavigationOptions? navigationOptions = null, com.mapbox.search.RouteOptions? routeOptions = null, java.util.Map<java.lang.String,java.lang.String>? unsafeParameters = null, boolean ignoreIndexableRecords = false, Double? indexableRecordsDistanceThresholdMeters = null, java.util.List<? extends com.mapbox.search.AttributeSet>? attributeSets = null);
     ctor public SearchOptions(com.mapbox.geojson.Point? proximity = null, com.mapbox.geojson.BoundingBox? boundingBox = null, java.util.List<com.mapbox.search.common.IsoCountryCode>? countries = null, Boolean? fuzzyMatch = null, java.util.List<com.mapbox.search.common.IsoLanguageCode>? languages = defaultSearchOptionsLanguage(), Integer? limit = null, java.util.List<? extends com.mapbox.search.QueryType>? types = null, Integer? requestDebounce = null, com.mapbox.geojson.Point? origin = null, com.mapbox.search.SearchNavigationOptions? navigationOptions = null, com.mapbox.search.RouteOptions? routeOptions = null, java.util.Map<java.lang.String,java.lang.String>? unsafeParameters = null, boolean ignoreIndexableRecords = false, Double? indexableRecordsDistanceThresholdMeters = null);
     ctor public SearchOptions(com.mapbox.geojson.Point? proximity = null, com.mapbox.geojson.BoundingBox? boundingBox = null, java.util.List<com.mapbox.search.common.IsoCountryCode>? countries = null, Boolean? fuzzyMatch = null, java.util.List<com.mapbox.search.common.IsoLanguageCode>? languages = defaultSearchOptionsLanguage(), Integer? limit = null, java.util.List<? extends com.mapbox.search.QueryType>? types = null, Integer? requestDebounce = null, com.mapbox.geojson.Point? origin = null, com.mapbox.search.SearchNavigationOptions? navigationOptions = null, com.mapbox.search.RouteOptions? routeOptions = null, java.util.Map<java.lang.String,java.lang.String>? unsafeParameters = null, boolean ignoreIndexableRecords = false);
     ctor public SearchOptions(com.mapbox.geojson.Point? proximity = null, com.mapbox.geojson.BoundingBox? boundingBox = null, java.util.List<com.mapbox.search.common.IsoCountryCode>? countries = null, Boolean? fuzzyMatch = null, java.util.List<com.mapbox.search.common.IsoLanguageCode>? languages = defaultSearchOptionsLanguage(), Integer? limit = null, java.util.List<? extends com.mapbox.search.QueryType>? types = null, Integer? requestDebounce = null, com.mapbox.geojson.Point? origin = null, com.mapbox.search.SearchNavigationOptions? navigationOptions = null, com.mapbox.search.RouteOptions? routeOptions = null, java.util.Map<java.lang.String,java.lang.String>? unsafeParameters = null);
@@ -327,7 +326,6 @@ package com.mapbox.search {
     ctor public SearchOptions(com.mapbox.geojson.Point? proximity = null, com.mapbox.geojson.BoundingBox? boundingBox = null, java.util.List<com.mapbox.search.common.IsoCountryCode>? countries = null);
     ctor public SearchOptions(com.mapbox.geojson.Point? proximity = null, com.mapbox.geojson.BoundingBox? boundingBox = null);
     ctor public SearchOptions(com.mapbox.geojson.Point? proximity = null);
-    method public java.util.List<com.mapbox.search.AttributeSet>? getAttributeSets();
     method public com.mapbox.geojson.BoundingBox? getBoundingBox();
     method public java.util.List<com.mapbox.search.common.IsoCountryCode>? getCountries();
     method public Boolean? getFuzzyMatch();
@@ -343,7 +341,6 @@ package com.mapbox.search {
     method public java.util.List<com.mapbox.search.QueryType>? getTypes();
     method public java.util.Map<java.lang.String,java.lang.String>? getUnsafeParameters();
     method public com.mapbox.search.SearchOptions.Builder toBuilder();
-    property public final java.util.List<com.mapbox.search.AttributeSet>? attributeSets;
     property public final com.mapbox.geojson.BoundingBox? boundingBox;
     property public final java.util.List<com.mapbox.search.common.IsoCountryCode>? countries;
     property public final Boolean? fuzzyMatch;
@@ -362,7 +359,6 @@ package com.mapbox.search {
 
   public static final class SearchOptions.Builder {
     ctor public SearchOptions.Builder();
-    method public com.mapbox.search.SearchOptions.Builder attributeSet(java.util.List<? extends com.mapbox.search.AttributeSet>? attributeSet);
     method public com.mapbox.search.SearchOptions.Builder boundingBox(com.mapbox.geojson.BoundingBox boundingBox);
     method public com.mapbox.search.SearchOptions build();
     method public com.mapbox.search.SearchOptions.Builder countries(com.mapbox.search.common.IsoCountryCode... countries);
@@ -481,9 +477,14 @@ package com.mapbox.search {
   }
 
   @kotlinx.parcelize.Parcelize public final class SelectOptions implements android.os.Parcelable {
-    ctor public SelectOptions(boolean addResultToHistory = true);
+    ctor public SelectOptions(boolean addResultToHistory = true, java.util.List<? extends com.mapbox.search.AttributeSet>? attributeSets = null);
     method public boolean getAddResultToHistory();
+    method public java.util.List<com.mapbox.search.AttributeSet>? getAttributeSets();
     property public final boolean addResultToHistory;
+    property public final java.util.List<com.mapbox.search.AttributeSet>? attributeSets;
+  }
+
+  public final class SelectOptionsKt {
   }
 
   public interface ServiceProvider {

--- a/MapboxSearch/sdk/api/sdk.api
+++ b/MapboxSearch/sdk/api/sdk.api
@@ -434,13 +434,11 @@ public final class com/mapbox/search/SearchOptions : android/os/Parcelable {
 	public fun <init> (Lcom/mapbox/geojson/Point;Lcom/mapbox/geojson/BoundingBox;Ljava/util/List;Ljava/lang/Boolean;Ljava/util/List;Ljava/lang/Integer;Ljava/util/List;Ljava/lang/Integer;Lcom/mapbox/geojson/Point;Lcom/mapbox/search/SearchNavigationOptions;Lcom/mapbox/search/RouteOptions;Ljava/util/Map;)V
 	public fun <init> (Lcom/mapbox/geojson/Point;Lcom/mapbox/geojson/BoundingBox;Ljava/util/List;Ljava/lang/Boolean;Ljava/util/List;Ljava/lang/Integer;Ljava/util/List;Ljava/lang/Integer;Lcom/mapbox/geojson/Point;Lcom/mapbox/search/SearchNavigationOptions;Lcom/mapbox/search/RouteOptions;Ljava/util/Map;Z)V
 	public fun <init> (Lcom/mapbox/geojson/Point;Lcom/mapbox/geojson/BoundingBox;Ljava/util/List;Ljava/lang/Boolean;Ljava/util/List;Ljava/lang/Integer;Ljava/util/List;Ljava/lang/Integer;Lcom/mapbox/geojson/Point;Lcom/mapbox/search/SearchNavigationOptions;Lcom/mapbox/search/RouteOptions;Ljava/util/Map;ZLjava/lang/Double;)V
-	public fun <init> (Lcom/mapbox/geojson/Point;Lcom/mapbox/geojson/BoundingBox;Ljava/util/List;Ljava/lang/Boolean;Ljava/util/List;Ljava/lang/Integer;Ljava/util/List;Ljava/lang/Integer;Lcom/mapbox/geojson/Point;Lcom/mapbox/search/SearchNavigationOptions;Lcom/mapbox/search/RouteOptions;Ljava/util/Map;ZLjava/lang/Double;Ljava/util/List;)V
-	public synthetic fun <init> (Lcom/mapbox/geojson/Point;Lcom/mapbox/geojson/BoundingBox;Ljava/util/List;Ljava/lang/Boolean;Ljava/util/List;Ljava/lang/Integer;Ljava/util/List;Ljava/lang/Integer;Lcom/mapbox/geojson/Point;Lcom/mapbox/search/SearchNavigationOptions;Lcom/mapbox/search/RouteOptions;Ljava/util/Map;ZLjava/lang/Double;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final synthetic fun copy (Lcom/mapbox/geojson/Point;Lcom/mapbox/geojson/BoundingBox;Ljava/util/List;Ljava/lang/Boolean;Ljava/util/List;Ljava/lang/Integer;Ljava/util/List;Ljava/lang/Integer;Lcom/mapbox/geojson/Point;Lcom/mapbox/search/SearchNavigationOptions;Lcom/mapbox/search/RouteOptions;Ljava/util/Map;ZLjava/lang/Double;Ljava/util/List;)Lcom/mapbox/search/SearchOptions;
-	public static synthetic fun copy$default (Lcom/mapbox/search/SearchOptions;Lcom/mapbox/geojson/Point;Lcom/mapbox/geojson/BoundingBox;Ljava/util/List;Ljava/lang/Boolean;Ljava/util/List;Ljava/lang/Integer;Ljava/util/List;Ljava/lang/Integer;Lcom/mapbox/geojson/Point;Lcom/mapbox/search/SearchNavigationOptions;Lcom/mapbox/search/RouteOptions;Ljava/util/Map;ZLjava/lang/Double;Ljava/util/List;ILjava/lang/Object;)Lcom/mapbox/search/SearchOptions;
+	public synthetic fun <init> (Lcom/mapbox/geojson/Point;Lcom/mapbox/geojson/BoundingBox;Ljava/util/List;Ljava/lang/Boolean;Ljava/util/List;Ljava/lang/Integer;Ljava/util/List;Ljava/lang/Integer;Lcom/mapbox/geojson/Point;Lcom/mapbox/search/SearchNavigationOptions;Lcom/mapbox/search/RouteOptions;Ljava/util/Map;ZLjava/lang/Double;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final synthetic fun copy (Lcom/mapbox/geojson/Point;Lcom/mapbox/geojson/BoundingBox;Ljava/util/List;Ljava/lang/Boolean;Ljava/util/List;Ljava/lang/Integer;Ljava/util/List;Ljava/lang/Integer;Lcom/mapbox/geojson/Point;Lcom/mapbox/search/SearchNavigationOptions;Lcom/mapbox/search/RouteOptions;Ljava/util/Map;ZLjava/lang/Double;)Lcom/mapbox/search/SearchOptions;
+	public static synthetic fun copy$default (Lcom/mapbox/search/SearchOptions;Lcom/mapbox/geojson/Point;Lcom/mapbox/geojson/BoundingBox;Ljava/util/List;Ljava/lang/Boolean;Ljava/util/List;Ljava/lang/Integer;Ljava/util/List;Ljava/lang/Integer;Lcom/mapbox/geojson/Point;Lcom/mapbox/search/SearchNavigationOptions;Lcom/mapbox/search/RouteOptions;Ljava/util/Map;ZLjava/lang/Double;ILjava/lang/Object;)Lcom/mapbox/search/SearchOptions;
 	public fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun getAttributeSets ()Ljava/util/List;
 	public final fun getBoundingBox ()Lcom/mapbox/geojson/BoundingBox;
 	public final fun getCountries ()Ljava/util/List;
 	public final fun getFuzzyMatch ()Ljava/lang/Boolean;
@@ -463,7 +461,6 @@ public final class com/mapbox/search/SearchOptions : android/os/Parcelable {
 
 public final class com/mapbox/search/SearchOptions$Builder {
 	public fun <init> ()V
-	public final fun attributeSet (Ljava/util/List;)Lcom/mapbox/search/SearchOptions$Builder;
 	public final fun boundingBox (Lcom/mapbox/geojson/BoundingBox;)Lcom/mapbox/search/SearchOptions$Builder;
 	public final fun build ()Lcom/mapbox/search/SearchOptions;
 	public final fun countries (Ljava/util/List;)Lcom/mapbox/search/SearchOptions$Builder;
@@ -566,11 +563,12 @@ public abstract interface class com/mapbox/search/SearchSuggestionsCallback {
 public final class com/mapbox/search/SelectOptions : android/os/Parcelable {
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public fun <init> ()V
-	public fun <init> (Z)V
-	public synthetic fun <init> (ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (ZLjava/util/List;)V
+	public synthetic fun <init> (ZLjava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getAddResultToHistory ()Z
+	public final fun getAttributeSets ()Ljava/util/List;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 	public fun writeToParcel (Landroid/os/Parcel;I)V

--- a/MapboxSearch/sdk/src/androidTest/java/com/mapbox/search/SearchEngineIntegrationTest.kt
+++ b/MapboxSearch/sdk/src/androidTest/java/com/mapbox/search/SearchEngineIntegrationTest.kt
@@ -755,6 +755,25 @@ internal class SearchEngineIntegrationTest : BaseTest() {
     }
 
     @Test
+    fun testSearchSelectionWithRetrieveOptions() {
+        mockServer.enqueue(createSuccessfulResponse("sbs_responses/suggestions-successful-random.json"))
+
+        var callback = BlockingSearchSelectionCallback()
+        searchEngine.search(TEST_QUERY, SearchOptions(), callback)
+
+        val suggestResponse = callback.getResultBlocking()
+        val suggestions = (suggestResponse as SearchEngineResult.Suggestions).suggestions
+
+        mockServer.enqueue(createSuccessfulResponse("sbs_responses/retrieve-no-results.json"))
+
+        callback = BlockingSearchSelectionCallback()
+        searchEngine.select(suggestions.first(), callback)
+
+        val selectResponse = callback.getResultBlocking()
+        assertTrue(selectResponse is SearchEngineResult.Error && selectResponse.e is SearchRequestException && selectResponse.e.code == 404)
+    }
+
+    @Test
     fun testSuccessfulSuggestionSelectionWithTurnedOffAddToHistoryLogic() {
         val blockingCompletionCallback = BlockingCompletionCallback<List<HistoryRecord>>()
         historyDataProvider.getAll(blockingCompletionCallback)

--- a/MapboxSearch/sdk/src/main/java/com/mapbox/search/CategorySearchOptions.kt
+++ b/MapboxSearch/sdk/src/main/java/com/mapbox/search/CategorySearchOptions.kt
@@ -409,6 +409,5 @@ internal fun CategorySearchOptions.mapToCoreCategory(): CoreSearchOptions = Core
     routeOptions?.route,
     routeOptions?.deviation?.sarType?.rawName,
     routeOptions?.timeDeviationMinutes,
-    unsafeParameters?.let { (it as? HashMap) ?: HashMap(it) },
-    null,
+    unsafeParameters?.let { (it as? HashMap) ?: HashMap(it) }
 )

--- a/MapboxSearch/sdk/src/main/java/com/mapbox/search/SearchEngineImpl.kt
+++ b/MapboxSearch/sdk/src/main/java/com/mapbox/search/SearchEngineImpl.kt
@@ -286,6 +286,7 @@ internal class SearchEngineImpl(
                     val requestId = coreEngine.retrieve(
                         coreRequestOptions,
                         base.rawSearchResult.mapToCore(),
+                        options.mapToCore(),
                         TwoStepsRequestCallbackWrapper(
                             apiType = apiType.mapToCore(),
                             coreEngine = coreEngine,

--- a/MapboxSearch/sdk/src/main/java/com/mapbox/search/SearchOptions.kt
+++ b/MapboxSearch/sdk/src/main/java/com/mapbox/search/SearchOptions.kt
@@ -117,14 +117,6 @@ public class SearchOptions @JvmOverloads public constructor(
      * Threshold specified in meters.
      */
     public val indexableRecordsDistanceThresholdMeters: Double? = null,
-
-    /**
-     * Besides the basic metadata attributes, developers can request additional
-     * attributes by setting attribute_sets parameter with attribute set values,
-     * for example &attribute_sets=basic,photos,visit.
-     * The requested metadata will be provided in metadata object in the response.
-     */
-    public val attributeSets: List<AttributeSet>? = null,
 ) : Parcelable {
 
     init {
@@ -153,7 +145,6 @@ public class SearchOptions @JvmOverloads public constructor(
         unsafeParameters: Map<String, String>? = this.unsafeParameters,
         ignoreIndexableRecords: Boolean = this.ignoreIndexableRecords,
         indexableRecordsDistanceThresholdMeters: Double? = this.indexableRecordsDistanceThresholdMeters,
-        attributeSets: List<AttributeSet>? = this.attributeSets,
     ): SearchOptions {
         return SearchOptions(
             proximity = proximity,
@@ -170,7 +161,6 @@ public class SearchOptions @JvmOverloads public constructor(
             unsafeParameters = unsafeParameters,
             ignoreIndexableRecords = ignoreIndexableRecords,
             indexableRecordsDistanceThresholdMeters = indexableRecordsDistanceThresholdMeters,
-            attributeSets = attributeSets,
         )
     }
 
@@ -204,7 +194,6 @@ public class SearchOptions @JvmOverloads public constructor(
         if (unsafeParameters != other.unsafeParameters) return false
         if (ignoreIndexableRecords != other.ignoreIndexableRecords) return false
         if (!indexableRecordsDistanceThresholdMeters.safeCompareTo(other.indexableRecordsDistanceThresholdMeters)) return false
-        if (attributeSets != other.attributeSets) return false
 
         return true
     }
@@ -227,7 +216,6 @@ public class SearchOptions @JvmOverloads public constructor(
         result = 31 * result + (unsafeParameters?.hashCode() ?: 0)
         result = 31 * result + ignoreIndexableRecords.hashCode()
         result = 31 * result + indexableRecordsDistanceThresholdMeters.hashCode()
-        result = 31 * result + (attributeSets?.hashCode() ?: 0)
         return result
     }
 
@@ -250,7 +238,6 @@ public class SearchOptions @JvmOverloads public constructor(
                 "unsafeParameters=$unsafeParameters, " +
                 "ignoreIndexableRecords=$ignoreIndexableRecords, " +
                 "indexableRecordsDistanceThresholdMeters=$indexableRecordsDistanceThresholdMeters" +
-                "attributeSets=$attributeSets" +
                 ")"
     }
 
@@ -291,7 +278,6 @@ public class SearchOptions @JvmOverloads public constructor(
             unsafeParameters = options.unsafeParameters
             ignoreIndexableRecords = options.ignoreIndexableRecords
             indexableRecordsDistanceThresholdMeters = options.indexableRecordsDistanceThresholdMeters
-            attributeSet = options.attributeSets
         }
 
         /**
@@ -411,16 +397,6 @@ public class SearchOptions @JvmOverloads public constructor(
         }
 
         /**
-         * Besides the basic metadata attributes, developers can request additional
-         * attributes by setting attribute_sets parameter with attribute set values,
-         * for example &attribute_sets=basic,photos,visit.
-         * The requested metadata will be provided in metadata object in the response.
-         */
-        public fun attributeSet(attributeSet: List<AttributeSet>?): Builder = apply {
-            this.attributeSet = attributeSet
-        }
-
-        /**
          * Create [SearchOptions] instance from builder data.
          */
         public fun build(): SearchOptions = SearchOptions(
@@ -438,7 +414,6 @@ public class SearchOptions @JvmOverloads public constructor(
             unsafeParameters = unsafeParameters,
             ignoreIndexableRecords = ignoreIndexableRecords,
             indexableRecordsDistanceThresholdMeters = indexableRecordsDistanceThresholdMeters,
-            attributeSets = attributeSet
         )
     }
 }
@@ -475,8 +450,7 @@ internal fun SearchOptions.mapToCore(): CoreSearchOptions = CoreSearchOptions(
     routeOptions?.route,
     routeOptions?.deviation?.sarType?.rawName,
     routeOptions?.timeDeviationMinutes,
-    unsafeParameters?.let { (it as? HashMap) ?: HashMap(it) },
-    attributeSets?.map { it.mapToCore() }
+    unsafeParameters?.let { (it as? HashMap) ?: HashMap(it) }
 )
 
 @JvmSynthetic
@@ -507,6 +481,5 @@ internal fun CoreSearchOptions.mapToPlatform(): SearchOptions = SearchOptions(
     } else null,
     unsafeParameters = addonAPI,
     ignoreIndexableRecords = ignoreUR,
-    indexableRecordsDistanceThresholdMeters = urDistanceThreshold,
-    attributeSets = attributeSets?.map { it.mapToPlatform() },
+    indexableRecordsDistanceThresholdMeters = urDistanceThreshold
 )

--- a/MapboxSearch/sdk/src/main/java/com/mapbox/search/SelectOptions.kt
+++ b/MapboxSearch/sdk/src/main/java/com/mapbox/search/SelectOptions.kt
@@ -1,7 +1,9 @@
 package com.mapbox.search
 
 import android.os.Parcelable
+import com.mapbox.search.base.core.CoreRetrieveOptions
 import kotlinx.parcelize.Parcelize
+import java.util.Objects
 
 /**
  * Bunch of options used by [SearchEngine.select] function.
@@ -14,6 +16,17 @@ public class SelectOptions public constructor(
      * Flag to control whether search result should be added to history automatically. Defaults to true.
      */
     public val addResultToHistory: Boolean = true,
+
+    /**
+     * Besides the basic metadata attributes, developers can request additional
+     * attributes by setting attribute_sets parameter with attribute set values,
+     * for example &attribute_sets=basic,photos,visit.
+     * The requested metadata will be provided in metadata object in the response.
+     *
+     * Note: this method is only used supported for [ApiType.SEARCH_BOX]
+     */
+    @Reserved(Reserved.Flags.SEARCH_BOX)
+    public val attributeSets: List<AttributeSet>? = null,
 ) : Parcelable {
 
     /**
@@ -26,6 +39,7 @@ public class SelectOptions public constructor(
         other as SelectOptions
 
         if (addResultToHistory != other.addResultToHistory) return false
+        if (attributeSets != other.attributeSets) return false
 
         return true
     }
@@ -34,7 +48,7 @@ public class SelectOptions public constructor(
      * @suppress
      */
     override fun hashCode(): Int {
-        return addResultToHistory.hashCode()
+        return Objects.hash(addResultToHistory, attributeSets)
     }
 
     /**
@@ -42,7 +56,13 @@ public class SelectOptions public constructor(
      */
     override fun toString(): String {
         return "SelectOptions(" +
-            "addResultToHistory=$addResultToHistory" +
-            ")"
+                "addResultToHistory=$addResultToHistory" +
+                "attributeSets=$attributeSets" +
+                ")"
     }
 }
+
+@JvmSynthetic
+internal fun SelectOptions.mapToCore(): CoreRetrieveOptions = CoreRetrieveOptions(
+    attributeSets = attributeSets?.map { it.mapToCore() }
+)

--- a/MapboxSearch/sdk/src/test/java/com/mapbox/search/SearchEngineTest.kt
+++ b/MapboxSearch/sdk/src/test/java/com/mapbox/search/SearchEngineTest.kt
@@ -582,6 +582,93 @@ internal class SearchEngineTest {
     }
 
     @TestFactory
+    fun `Check successful search selection with all attribute sets`() = TestCase {
+        Given("SearchEngine with mocked dependencies") {
+            every {
+                coreEngine.retrieve(any(), any(), any(), any())
+            } answers {
+                TEST_REQUEST_ID
+            }
+
+            When("Suggestion selected") {
+                val callback = mockk<SearchSelectionCallback>(relaxed = true)
+                val options = SelectOptions(
+                    attributeSets = AttributeSet.values().toList()
+                )
+
+                val task = searchEngine.select(
+                    suggestion = TEST_SBS_SERVER_SEARCH_SUGGESTION.mapToPlatform(),
+                    options = options,
+                    executor = executor,
+                    callback = callback,
+                )
+
+                Verify("CoreSearchEngine.retrieve() Called") {
+                    coreEngine.retrieve(any(), any(), options.mapToCore(), any())
+                }
+            }
+        }
+    }
+
+    @TestFactory
+    fun `Check successful search selection with subset of attribute sets`() = TestCase {
+        Given("SearchEngine with mocked dependencies") {
+            every {
+                coreEngine.retrieve(any(), any(), any(), any())
+            } answers {
+                TEST_REQUEST_ID
+            }
+
+            When("Suggestion selected") {
+                val callback = mockk<SearchSelectionCallback>(relaxed = true)
+                val options = SelectOptions(
+                    attributeSets = listOf(AttributeSet.BASIC, AttributeSet.VENUE)
+                )
+
+                val task = searchEngine.select(
+                    suggestion = TEST_SBS_SERVER_SEARCH_SUGGESTION.mapToPlatform(),
+                    options = options,
+                    executor = executor,
+                    callback = callback,
+                )
+
+                Verify("CoreSearchEngine.retrieve() Called") {
+                    coreEngine.retrieve(any(), any(), options.mapToCore(), any())
+                }
+            }
+        }
+    }
+
+    @TestFactory
+    fun `Check successful search selection with one attribute sets`() = TestCase {
+        Given("SearchEngine with mocked dependencies") {
+            every {
+                coreEngine.retrieve(any(), any(), any(), any())
+            } answers {
+                TEST_REQUEST_ID
+            }
+
+            When("Suggestion selected") {
+                val callback = mockk<SearchSelectionCallback>(relaxed = true)
+                val options = SelectOptions(
+                    attributeSets = listOf(AttributeSet.PHOTOS)
+                )
+
+                val task = searchEngine.select(
+                    suggestion = TEST_SBS_SERVER_SEARCH_SUGGESTION.mapToPlatform(),
+                    options = options,
+                    executor = executor,
+                    callback = callback,
+                )
+
+                Verify("CoreSearchEngine.retrieve() Called") {
+                    coreEngine.retrieve(any(), any(), options.mapToCore(), any())
+                }
+            }
+        }
+    }
+
+    @TestFactory
     fun `Check successful search selection with data layer suggestion`() = TestCase {
         Given("SearchEngine with mocked dependencies") {
             val slotRequestOptions = slot<CoreRequestOptions>()

--- a/MapboxSearch/sdk/src/test/java/com/mapbox/search/SearchEngineTest.kt
+++ b/MapboxSearch/sdk/src/test/java/com/mapbox/search/SearchEngineTest.kt
@@ -596,7 +596,7 @@ internal class SearchEngineTest {
                     attributeSets = AttributeSet.values().toList()
                 )
 
-                val task = searchEngine.select(
+                searchEngine.select(
                     suggestion = TEST_SBS_SERVER_SEARCH_SUGGESTION.mapToPlatform(),
                     options = options,
                     executor = executor,
@@ -625,7 +625,7 @@ internal class SearchEngineTest {
                     attributeSets = listOf(AttributeSet.BASIC, AttributeSet.VENUE)
                 )
 
-                val task = searchEngine.select(
+                searchEngine.select(
                     suggestion = TEST_SBS_SERVER_SEARCH_SUGGESTION.mapToPlatform(),
                     options = options,
                     executor = executor,
@@ -654,7 +654,7 @@ internal class SearchEngineTest {
                     attributeSets = listOf(AttributeSet.PHOTOS)
                 )
 
-                val task = searchEngine.select(
+                searchEngine.select(
                     suggestion = TEST_SBS_SERVER_SEARCH_SUGGESTION.mapToPlatform(),
                     options = options,
                     executor = executor,

--- a/MapboxSearch/sdk/src/test/java/com/mapbox/search/SearchEngineTest.kt
+++ b/MapboxSearch/sdk/src/test/java/com/mapbox/search/SearchEngineTest.kt
@@ -753,7 +753,7 @@ internal class SearchEngineTest {
 
             val slotRetrieveSearchCallback = slot<CoreSearchCallback>()
             every {
-                coreEngine.retrieve(any(), any(), capture(slotRetrieveSearchCallback))
+                coreEngine.retrieve(any(), any(), any(), capture(slotRetrieveSearchCallback))
             } answers {
                 slotRetrieveSearchCallback.captured.run(TEST_SUCCESSFUL_CORE_RESPONSE)
                 TEST_REQUEST_ID

--- a/MapboxSearch/sdk/src/test/java/com/mapbox/search/SearchEngineTest.kt
+++ b/MapboxSearch/sdk/src/test/java/com/mapbox/search/SearchEngineTest.kt
@@ -497,7 +497,7 @@ internal class SearchEngineTest {
 
             val slotRetrieveSearchCallback = slot<CoreSearchCallback>()
             every {
-                coreEngine.retrieve(any(), any(), capture(slotRetrieveSearchCallback))
+                coreEngine.retrieve(any(), any(), any(), capture(slotRetrieveSearchCallback))
             } answers {
                 slotRetrieveSearchCallback.captured.run(TEST_SUCCESSFUL_CORE_RESPONSE)
                 TEST_REQUEST_ID
@@ -520,7 +520,7 @@ internal class SearchEngineTest {
                 )
 
                 Verify("CoreSearchEngine.retrieve() Called") {
-                    coreEngine.retrieve(any(), any(), any())
+                    coreEngine.retrieve(any(), any(), any(), any())
                 }
 
                 Then("Task is executed", true, task.isDone)
@@ -788,7 +788,7 @@ internal class SearchEngineTest {
     fun `Check search selection cancellation initiated by user`() = TestCase {
         Given("SearchEngine with mocked dependencies") {
             every {
-                coreEngine.retrieve(any(), any(), any())
+                coreEngine.retrieve(any(), any(), any(), any())
             } answers {
                 TEST_REQUEST_ID
             }

--- a/MapboxSearch/sdk/src/test/java/com/mapbox/search/SearchOptionsTest.kt
+++ b/MapboxSearch/sdk/src/test/java/com/mapbox/search/SearchOptionsTest.kt
@@ -2,7 +2,6 @@ package com.mapbox.search
 
 import com.mapbox.geojson.BoundingBox
 import com.mapbox.geojson.Point
-import com.mapbox.search.base.core.CoreAttributeSet
 import com.mapbox.search.base.utils.extension.mapToCore
 import com.mapbox.search.common.IsoCountryCode
 import com.mapbox.search.common.IsoLanguageCode
@@ -202,8 +201,7 @@ internal class SearchOptionsTest {
                     route = TEST_ROUTE_OPTIONS.route,
                     sarType = "isochrone",
                     timeDeviation = TEST_ROUTE_OPTIONS.timeDeviationMinutes,
-                    addonAPI = HashMap(TEST_UNSAFE_PARAMETERS),
-                    attributeSets = listOf(CoreAttributeSet.BASIC, CoreAttributeSet.PHOTOS)
+                    addonAPI = HashMap(TEST_UNSAFE_PARAMETERS)
                 )
 
                 Then("Options should be equal", expectedOptions, actualOptions)

--- a/MapboxSearch/sdk/src/test/java/com/mapbox/search/SearchOptionsTest.kt
+++ b/MapboxSearch/sdk/src/test/java/com/mapbox/search/SearchOptionsTest.kt
@@ -51,7 +51,6 @@ internal class SearchOptionsTest {
                     unsafeParameters = null,
                     ignoreIndexableRecords = false,
                     indexableRecordsDistanceThresholdMeters = null,
-                    attributeSets = null,
                 )
 
                 Then("Options should be equal", expectedOptions, actualOptions)
@@ -79,7 +78,6 @@ internal class SearchOptionsTest {
                     .unsafeParameters(TEST_UNSAFE_PARAMETERS)
                     .ignoreIndexableRecords(true)
                     .indexableRecordsDistanceThresholdMeters(50.0)
-                    .attributeSet(listOf(AttributeSet.BASIC))
                     .build()
 
                 val expectedOptions = SearchOptions(
@@ -96,8 +94,7 @@ internal class SearchOptionsTest {
                     routeOptions = TEST_ROUTE_OPTIONS,
                     unsafeParameters = TEST_UNSAFE_PARAMETERS,
                     ignoreIndexableRecords = true,
-                    indexableRecordsDistanceThresholdMeters = 50.0,
-                    attributeSets = listOf(AttributeSet.BASIC)
+                    indexableRecordsDistanceThresholdMeters = 50.0
                 )
 
                 Then("Options should be equal", expectedOptions, actualOptions)
@@ -125,7 +122,6 @@ internal class SearchOptionsTest {
                     .unsafeParameters(TEST_UNSAFE_PARAMETERS)
                     .ignoreIndexableRecords(true)
                     .indexableRecordsDistanceThresholdMeters(100.123)
-                    .attributeSet(listOf(AttributeSet.BASIC, AttributeSet.PHOTOS, AttributeSet.VISIT, AttributeSet.VENUE))
                     .build()
 
                 val expectedOptions = SearchOptions(
@@ -142,8 +138,7 @@ internal class SearchOptionsTest {
                     routeOptions = TEST_ROUTE_OPTIONS,
                     unsafeParameters = TEST_UNSAFE_PARAMETERS,
                     ignoreIndexableRecords = true,
-                    indexableRecordsDistanceThresholdMeters = 100.123,
-                    attributeSets = listOf(AttributeSet.BASIC, AttributeSet.PHOTOS, AttributeSet.VISIT, AttributeSet.VENUE)
+                    indexableRecordsDistanceThresholdMeters = 100.123
                 )
 
                 Then("Options should be equal", expectedOptions, actualOptions)
@@ -186,7 +181,6 @@ internal class SearchOptionsTest {
                     .unsafeParameters(TEST_UNSAFE_PARAMETERS)
                     .ignoreIndexableRecords(true)
                     .indexableRecordsDistanceThresholdMeters(15.0)
-                    .attributeSet(listOf(AttributeSet.BASIC, AttributeSet.PHOTOS))
                     .build()
 
                 val actualOptions = originalOptions.mapToCore()
@@ -235,8 +229,7 @@ internal class SearchOptionsTest {
                     routeOptions = TEST_ROUTE_OPTIONS,
                     unsafeParameters = TEST_UNSAFE_PARAMETERS,
                     ignoreIndexableRecords = true,
-                    indexableRecordsDistanceThresholdMeters = 11.0,
-                    attributeSets = listOf(AttributeSet.VENUE)
+                    indexableRecordsDistanceThresholdMeters = 11.0
                 )
 
                 Then("Options should be equal", options, options.toBuilder().build())

--- a/MapboxSearch/sdk/src/test/java/com/mapbox/search/SelectOptionsTest.kt
+++ b/MapboxSearch/sdk/src/test/java/com/mapbox/search/SelectOptionsTest.kt
@@ -1,0 +1,36 @@
+package com.mapbox.search
+
+import com.mapbox.search.base.core.CoreAttributeSet
+import com.mapbox.search.base.core.CoreRetrieveOptions
+import com.mapbox.test.dsl.TestCase
+import org.junit.jupiter.api.TestFactory
+
+internal class SelectOptionsTest {
+    @TestFactory
+    fun `Check empty SelectOptions mapToCore()`() = TestCase {
+        Given("empty SelectOptions") {
+            val selectOptions = SelectOptions()
+
+            When(".mapToCore()") {
+                val actual = selectOptions.mapToCore()
+                val expected = CoreRetrieveOptions(null)
+
+                Then("Options should be as expected", expected, actual)
+            }
+        }
+    }
+
+    @TestFactory
+    fun `Check SelectOptions mapToCore()`() = TestCase {
+        Given("SelectOptions with AttributeSets") {
+            val selectOptions = SelectOptions(attributeSets = AttributeSet.values().toList())
+
+            When(".mapToCore()") {
+                val actual = selectOptions.mapToCore()
+                val expected = CoreRetrieveOptions(CoreAttributeSet.values().toList())
+
+                Then("Options should be as expected", expected, actual)
+            }
+        }
+    }
+}


### PR DESCRIPTION
<!-- ⚠️ TEMPLATE ⚠️ -->
<!-- Template for GitHub PR descriptions. Use it as a guide on how to describe your work. Feel free to remove any section when you're opening a PR if you think it does not apply for your committed changes. -->

### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->

Aligning `SearchOptions` with the latest Search Native v2.3.0. I also added `List<AttributeSet>` to the `SelectOptions` to match `RetrieveOptions` from the native search sdk. This also bumps common sdk to v24.6.0.

### Screenshots or Gifs
<!-- 
Include media files to provide additional context. It's REALLY useful for UI related PRs (e.g. ![screenshot gif](link))

Please note that you can change image width/height with one of the following ways:
- For specifying size in percentage:
<img src="https://user-images.githubusercontent.com/4005589/120349671-f86c4f80-c306-11eb-8c71-b903666c2bc.png" width=50% height=50%>
- For specifying size in pixels:
<img src="https://user-images.githubusercontent.com/4005589/120349671-f86c4f80-c306-11eb-8c71-b903666c2bc.png" width="200" height="200">
-->


### Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have updated the `CHANGELOG` including this PR (where applicable)
- [x] I have run tests and automatic checks locally
- [x] I have run `pitest` check locally and checked that the coverage increased (or didn't change) or decreased insignificantly
- [x] I have made corresponding changes to the documentation (where applicable)
- [x] I have grouped commits logically or I promise to squash my commits before merge
