### PR TITLE
Search SDK 2.7; Attributes set for the category search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog for the Mapbox Search SDK for Android
 
+## 2.7.0
+
+### New features
+- New option `CategorySearchOptions.attributeSets` is available. It allows to request additional metadata attributes besides the basic ones.
+
+### Mapbox dependencies
+- Search Native SDK `2.7.0`
+- Common SDK `24.9.0`
+
+
+
 ## 2.7.0-rc.1
 
 ### New features

--- a/MapboxSearch/base/src/main/java/com/mapbox/search/base/core/CoreFactoryFunctions.kt
+++ b/MapboxSearch/base/src/main/java/com/mapbox/search/base/core/CoreFactoryFunctions.kt
@@ -1,6 +1,7 @@
 package com.mapbox.search.base.core
 
 import com.mapbox.geojson.Point
+import com.mapbox.search.internal.bindgen.AttributeSet
 import com.mapbox.search.internal.bindgen.LonLatBBox
 import com.mapbox.search.internal.bindgen.QueryType
 import com.mapbox.search.internal.bindgen.ReverseGeoOptions
@@ -27,6 +28,7 @@ fun createCoreSearchOptions(
     addonAPI: Map<String, String>? = null,
     offlineSearchPlacesOutsideBbox: Boolean = false,
     ensureResultsPerCategory: Boolean? = null,
+    attributeSets: List<AttributeSet>? = null,
 ): CoreSearchOptions = CoreSearchOptions(
     proximity = proximity,
     origin = origin,
@@ -47,6 +49,7 @@ fun createCoreSearchOptions(
     addonAPI = addonAPI?.let { it as? HashMap<String, String> ?: HashMap(it) },
     offlineSearchPlacesOutsideBbox = offlineSearchPlacesOutsideBbox,
     ensureResultsPerCategory = ensureResultsPerCategory,
+    attributeSets = attributeSets,
 )
 
 fun createCoreReverseGeoOptions(

--- a/MapboxSearch/common-tests/src/main/java/com/mapbox/search/common/tests/CoreTestDataFactory.kt
+++ b/MapboxSearch/common-tests/src/main/java/com/mapbox/search/common/tests/CoreTestDataFactory.kt
@@ -2,6 +2,7 @@ package com.mapbox.search.common.tests
 
 import com.mapbox.bindgen.ExpectedFactory
 import com.mapbox.geojson.Point
+import com.mapbox.search.internal.bindgen.AttributeSet
 import com.mapbox.search.internal.bindgen.ConnectionError
 import com.mapbox.search.internal.bindgen.HttpError
 import com.mapbox.search.internal.bindgen.ImageInfo
@@ -49,6 +50,7 @@ fun createTestCoreSearchOptions(
     addonAPI: Map<String, String>? = null,
     offlineSearchPlacesOutsideBbox: Boolean = false,
     ensureResultsPerCategory: Boolean? = null,
+    attributeSets: List<AttributeSet>? = null,
 ): SearchOptions = SearchOptions(
     proximity,
     origin,
@@ -69,6 +71,7 @@ fun createTestCoreSearchOptions(
     addonAPI?.let { it as? HashMap<String, String> ?: HashMap(it) },
     offlineSearchPlacesOutsideBbox,
     ensureResultsPerCategory,
+    attributeSets,
 )
 
 @Suppress("LongParameterList")

--- a/MapboxSearch/gradle.properties
+++ b/MapboxSearch/gradle.properties
@@ -21,7 +21,7 @@ android.enableJetifier=false
 kotlin.code.style=official
 
 # SDK version attributes
-VERSION_NAME=2.7.0-rc.1
+VERSION_NAME=2.7.0
 
 # Artifact attributes
 mapboxArtifactUserOrg=mapbox

--- a/MapboxSearch/gradle/versions.gradle
+++ b/MapboxSearch/gradle/versions.gradle
@@ -41,13 +41,13 @@ ext {
 
     pitest_version = '1.6.7'
 
-    mapbox_maps_version = '11.9.0-beta.1'
+    mapbox_maps_version = '11.9.0-rc.1'
     mapbox_turf_version = '6.15.0'
 
-    common_sdk_version = '24.9.0-rc.1'
+    common_sdk_version = '24.9.0'
     mapbox_base_version = '0.8.0'
 
-    search_native_version = '2.7.0-rc.1'
+    search_native_version = '2.7.0'
 
     detekt_version = '1.19.0'
 

--- a/MapboxSearch/sample/src/main/java/com/mapbox/search/sample/api/CategorySearchJavaExampleActivity.java
+++ b/MapboxSearch/sample/src/main/java/com/mapbox/search/sample/api/CategorySearchJavaExampleActivity.java
@@ -8,6 +8,7 @@ import androidx.annotation.Nullable;
 import androidx.appcompat.app.AppCompatActivity;
 
 import com.mapbox.search.ApiType;
+import com.mapbox.search.AttributeSet;
 import com.mapbox.search.CategorySearchOptions;
 import com.mapbox.search.ResponseInfo;
 import com.mapbox.search.SearchCallback;
@@ -52,6 +53,14 @@ public class CategorySearchJavaExampleActivity extends AppCompatActivity {
         final CategorySearchOptions options = new CategorySearchOptions.Builder()
             .limit(10)
             .ensureResultsPerCategory(true)
+            .attributeSets(
+                Arrays.asList(
+                    AttributeSet.BASIC,
+                    AttributeSet.VISIT,
+                    AttributeSet.VENUE,
+                    AttributeSet.PHOTOS
+                )
+            )
             .build();
 
         searchRequestTask = searchEngine.search(

--- a/MapboxSearch/sample/src/main/java/com/mapbox/search/sample/api/CategorySearchKotlinExampleActivity.kt
+++ b/MapboxSearch/sample/src/main/java/com/mapbox/search/sample/api/CategorySearchKotlinExampleActivity.kt
@@ -2,6 +2,7 @@ package com.mapbox.search.sample.api
 
 import android.os.Bundle
 import com.mapbox.search.ApiType
+import com.mapbox.search.AttributeSet
 import com.mapbox.search.CategorySearchOptions
 import com.mapbox.search.ResponseInfo
 import com.mapbox.search.SearchCallback
@@ -52,6 +53,12 @@ class CategorySearchKotlinExampleActivity : BaseKotlinExampleActivity() {
             CategorySearchOptions(
                 limit = 10,
                 ensureResultsPerCategory = true,
+                attributeSets = listOf(
+                    AttributeSet.BASIC,
+                    AttributeSet.VISIT,
+                    AttributeSet.VENUE,
+                    AttributeSet.PHOTOS,
+                ),
             ),
             searchCallback
         )

--- a/MapboxSearch/sdk/api/api-metalava.txt
+++ b/MapboxSearch/sdk/api/api-metalava.txt
@@ -21,6 +21,7 @@ package com.mapbox.search {
   }
 
   @kotlinx.parcelize.Parcelize public final class CategorySearchOptions implements android.os.Parcelable {
+    ctor public CategorySearchOptions(com.mapbox.geojson.Point? proximity = null, com.mapbox.geojson.BoundingBox? boundingBox = null, java.util.List<com.mapbox.search.common.IsoCountryCode>? countries = null, Boolean? fuzzyMatch = null, java.util.List<com.mapbox.search.common.IsoLanguageCode>? languages = defaultSearchOptionsLanguage(), Integer? limit = null, Integer? requestDebounce = null, com.mapbox.geojson.Point? origin = null, com.mapbox.search.common.NavigationProfile? navigationProfile = null, com.mapbox.search.RouteOptions? routeOptions = null, java.util.Map<java.lang.String,java.lang.String>? unsafeParameters = null, boolean ignoreIndexableRecords = false, Double? indexableRecordsDistanceThresholdMeters = null, Boolean? ensureResultsPerCategory = null, java.util.List<? extends com.mapbox.search.AttributeSet>? attributeSets = null);
     ctor public CategorySearchOptions(com.mapbox.geojson.Point? proximity = null, com.mapbox.geojson.BoundingBox? boundingBox = null, java.util.List<com.mapbox.search.common.IsoCountryCode>? countries = null, Boolean? fuzzyMatch = null, java.util.List<com.mapbox.search.common.IsoLanguageCode>? languages = defaultSearchOptionsLanguage(), Integer? limit = null, Integer? requestDebounce = null, com.mapbox.geojson.Point? origin = null, com.mapbox.search.common.NavigationProfile? navigationProfile = null, com.mapbox.search.RouteOptions? routeOptions = null, java.util.Map<java.lang.String,java.lang.String>? unsafeParameters = null, boolean ignoreIndexableRecords = false, Double? indexableRecordsDistanceThresholdMeters = null, Boolean? ensureResultsPerCategory = null);
     ctor public CategorySearchOptions(com.mapbox.geojson.Point? proximity = null, com.mapbox.geojson.BoundingBox? boundingBox = null, java.util.List<com.mapbox.search.common.IsoCountryCode>? countries = null, Boolean? fuzzyMatch = null, java.util.List<com.mapbox.search.common.IsoLanguageCode>? languages = defaultSearchOptionsLanguage(), Integer? limit = null, Integer? requestDebounce = null, com.mapbox.geojson.Point? origin = null, com.mapbox.search.common.NavigationProfile? navigationProfile = null, com.mapbox.search.RouteOptions? routeOptions = null, java.util.Map<java.lang.String,java.lang.String>? unsafeParameters = null, boolean ignoreIndexableRecords = false, Double? indexableRecordsDistanceThresholdMeters = null);
     ctor public CategorySearchOptions(com.mapbox.geojson.Point? proximity = null, com.mapbox.geojson.BoundingBox? boundingBox = null, java.util.List<com.mapbox.search.common.IsoCountryCode>? countries = null, Boolean? fuzzyMatch = null, java.util.List<com.mapbox.search.common.IsoLanguageCode>? languages = defaultSearchOptionsLanguage(), Integer? limit = null, Integer? requestDebounce = null, com.mapbox.geojson.Point? origin = null, com.mapbox.search.common.NavigationProfile? navigationProfile = null, com.mapbox.search.RouteOptions? routeOptions = null, java.util.Map<java.lang.String,java.lang.String>? unsafeParameters = null, boolean ignoreIndexableRecords = false);
@@ -35,6 +36,7 @@ package com.mapbox.search {
     ctor public CategorySearchOptions(com.mapbox.geojson.Point? proximity = null, com.mapbox.geojson.BoundingBox? boundingBox = null, java.util.List<com.mapbox.search.common.IsoCountryCode>? countries = null);
     ctor public CategorySearchOptions(com.mapbox.geojson.Point? proximity = null, com.mapbox.geojson.BoundingBox? boundingBox = null);
     ctor public CategorySearchOptions(com.mapbox.geojson.Point? proximity = null);
+    method public java.util.List<com.mapbox.search.AttributeSet>? getAttributeSets();
     method public com.mapbox.geojson.BoundingBox? getBoundingBox();
     method public java.util.List<com.mapbox.search.common.IsoCountryCode>? getCountries();
     method public Boolean? getEnsureResultsPerCategory();
@@ -50,6 +52,7 @@ package com.mapbox.search {
     method public com.mapbox.search.RouteOptions? getRouteOptions();
     method public java.util.Map<java.lang.String,java.lang.String>? getUnsafeParameters();
     method public com.mapbox.search.CategorySearchOptions.Builder toBuilder();
+    property public final java.util.List<com.mapbox.search.AttributeSet>? attributeSets;
     property public final com.mapbox.geojson.BoundingBox? boundingBox;
     property public final java.util.List<com.mapbox.search.common.IsoCountryCode>? countries;
     property public final Boolean? ensureResultsPerCategory;
@@ -68,6 +71,7 @@ package com.mapbox.search {
 
   public static final class CategorySearchOptions.Builder {
     ctor public CategorySearchOptions.Builder();
+    method public com.mapbox.search.CategorySearchOptions.Builder attributeSets(java.util.List<? extends com.mapbox.search.AttributeSet>? attributeSets);
     method public com.mapbox.search.CategorySearchOptions.Builder boundingBox(com.mapbox.geojson.BoundingBox boundingBox);
     method public com.mapbox.search.CategorySearchOptions build();
     method public com.mapbox.search.CategorySearchOptions.Builder countries(com.mapbox.search.common.IsoCountryCode... countries);

--- a/MapboxSearch/sdk/api/sdk.api
+++ b/MapboxSearch/sdk/api/sdk.api
@@ -39,11 +39,13 @@ public final class com/mapbox/search/CategorySearchOptions : android/os/Parcelab
 	public fun <init> (Lcom/mapbox/geojson/Point;Lcom/mapbox/geojson/BoundingBox;Ljava/util/List;Ljava/lang/Boolean;Ljava/util/List;Ljava/lang/Integer;Ljava/lang/Integer;Lcom/mapbox/geojson/Point;Lcom/mapbox/search/common/NavigationProfile;Lcom/mapbox/search/RouteOptions;Ljava/util/Map;Z)V
 	public fun <init> (Lcom/mapbox/geojson/Point;Lcom/mapbox/geojson/BoundingBox;Ljava/util/List;Ljava/lang/Boolean;Ljava/util/List;Ljava/lang/Integer;Ljava/lang/Integer;Lcom/mapbox/geojson/Point;Lcom/mapbox/search/common/NavigationProfile;Lcom/mapbox/search/RouteOptions;Ljava/util/Map;ZLjava/lang/Double;)V
 	public fun <init> (Lcom/mapbox/geojson/Point;Lcom/mapbox/geojson/BoundingBox;Ljava/util/List;Ljava/lang/Boolean;Ljava/util/List;Ljava/lang/Integer;Ljava/lang/Integer;Lcom/mapbox/geojson/Point;Lcom/mapbox/search/common/NavigationProfile;Lcom/mapbox/search/RouteOptions;Ljava/util/Map;ZLjava/lang/Double;Ljava/lang/Boolean;)V
-	public synthetic fun <init> (Lcom/mapbox/geojson/Point;Lcom/mapbox/geojson/BoundingBox;Ljava/util/List;Ljava/lang/Boolean;Ljava/util/List;Ljava/lang/Integer;Ljava/lang/Integer;Lcom/mapbox/geojson/Point;Lcom/mapbox/search/common/NavigationProfile;Lcom/mapbox/search/RouteOptions;Ljava/util/Map;ZLjava/lang/Double;Ljava/lang/Boolean;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final synthetic fun copy (Lcom/mapbox/geojson/Point;Lcom/mapbox/geojson/BoundingBox;Ljava/util/List;Ljava/lang/Boolean;Ljava/util/List;Ljava/lang/Integer;Ljava/lang/Integer;Lcom/mapbox/geojson/Point;Lcom/mapbox/search/common/NavigationProfile;Lcom/mapbox/search/RouteOptions;Ljava/util/Map;ZLjava/lang/Double;Ljava/lang/Boolean;)Lcom/mapbox/search/CategorySearchOptions;
-	public static synthetic fun copy$default (Lcom/mapbox/search/CategorySearchOptions;Lcom/mapbox/geojson/Point;Lcom/mapbox/geojson/BoundingBox;Ljava/util/List;Ljava/lang/Boolean;Ljava/util/List;Ljava/lang/Integer;Ljava/lang/Integer;Lcom/mapbox/geojson/Point;Lcom/mapbox/search/common/NavigationProfile;Lcom/mapbox/search/RouteOptions;Ljava/util/Map;ZLjava/lang/Double;Ljava/lang/Boolean;ILjava/lang/Object;)Lcom/mapbox/search/CategorySearchOptions;
+	public fun <init> (Lcom/mapbox/geojson/Point;Lcom/mapbox/geojson/BoundingBox;Ljava/util/List;Ljava/lang/Boolean;Ljava/util/List;Ljava/lang/Integer;Ljava/lang/Integer;Lcom/mapbox/geojson/Point;Lcom/mapbox/search/common/NavigationProfile;Lcom/mapbox/search/RouteOptions;Ljava/util/Map;ZLjava/lang/Double;Ljava/lang/Boolean;Ljava/util/List;)V
+	public synthetic fun <init> (Lcom/mapbox/geojson/Point;Lcom/mapbox/geojson/BoundingBox;Ljava/util/List;Ljava/lang/Boolean;Ljava/util/List;Ljava/lang/Integer;Ljava/lang/Integer;Lcom/mapbox/geojson/Point;Lcom/mapbox/search/common/NavigationProfile;Lcom/mapbox/search/RouteOptions;Ljava/util/Map;ZLjava/lang/Double;Ljava/lang/Boolean;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final synthetic fun copy (Lcom/mapbox/geojson/Point;Lcom/mapbox/geojson/BoundingBox;Ljava/util/List;Ljava/lang/Boolean;Ljava/util/List;Ljava/lang/Integer;Ljava/lang/Integer;Lcom/mapbox/geojson/Point;Lcom/mapbox/search/common/NavigationProfile;Lcom/mapbox/search/RouteOptions;Ljava/util/Map;ZLjava/lang/Double;Ljava/lang/Boolean;Ljava/util/List;)Lcom/mapbox/search/CategorySearchOptions;
+	public static synthetic fun copy$default (Lcom/mapbox/search/CategorySearchOptions;Lcom/mapbox/geojson/Point;Lcom/mapbox/geojson/BoundingBox;Ljava/util/List;Ljava/lang/Boolean;Ljava/util/List;Ljava/lang/Integer;Ljava/lang/Integer;Lcom/mapbox/geojson/Point;Lcom/mapbox/search/common/NavigationProfile;Lcom/mapbox/search/RouteOptions;Ljava/util/Map;ZLjava/lang/Double;Ljava/lang/Boolean;Ljava/util/List;ILjava/lang/Object;)Lcom/mapbox/search/CategorySearchOptions;
 	public fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAttributeSets ()Ljava/util/List;
 	public final fun getBoundingBox ()Lcom/mapbox/geojson/BoundingBox;
 	public final fun getCountries ()Ljava/util/List;
 	public final fun getEnsureResultsPerCategory ()Ljava/lang/Boolean;
@@ -66,6 +68,7 @@ public final class com/mapbox/search/CategorySearchOptions : android/os/Parcelab
 
 public final class com/mapbox/search/CategorySearchOptions$Builder {
 	public fun <init> ()V
+	public final fun attributeSets (Ljava/util/List;)Lcom/mapbox/search/CategorySearchOptions$Builder;
 	public final fun boundingBox (Lcom/mapbox/geojson/BoundingBox;)Lcom/mapbox/search/CategorySearchOptions$Builder;
 	public final fun build ()Lcom/mapbox/search/CategorySearchOptions;
 	public final fun countries (Ljava/util/List;)Lcom/mapbox/search/CategorySearchOptions$Builder;

--- a/MapboxSearch/sdk/src/androidTest/java/com/mapbox/search/search_box/CategorySearchIntegrationTest.kt
+++ b/MapboxSearch/sdk/src/androidTest/java/com/mapbox/search/search_box/CategorySearchIntegrationTest.kt
@@ -4,6 +4,7 @@ import com.mapbox.common.MapboxOptions
 import com.mapbox.geojson.BoundingBox
 import com.mapbox.geojson.Point
 import com.mapbox.search.ApiType
+import com.mapbox.search.AttributeSet
 import com.mapbox.search.BaseTest
 import com.mapbox.search.BuildConfig
 import com.mapbox.search.CategorySearchOptions
@@ -122,6 +123,12 @@ internal class CategorySearchIntegrationTest : BaseTest() {
             navigationProfile = NavigationProfile.DRIVING,
             routeOptions = TEST_ROUTE_OPTIONS,
             ensureResultsPerCategory = true,
+            attributeSets = listOf(
+                AttributeSet.BASIC,
+                AttributeSet.VENUE,
+                AttributeSet.VISIT,
+                AttributeSet.PHOTOS,
+            )
         )
 
         searchEngine.categorySearchBlocking(TEST_CATEGORY, options)
@@ -150,6 +157,11 @@ internal class CategorySearchIntegrationTest : BaseTest() {
         assertEquals("polyline6", url.queryParameter("route_geometry"))
 
         assertEquals(options.ensureResultsPerCategory.toString(), url.queryParameter("ensure_results_per_category"))
+
+        assertEquals(
+            options.attributeSets!!.joinToString(separator = ",") { it.name.lowercase() },
+            url.queryParameter("attribute_sets")
+        )
 
         assertFalse(request.headers["X-Request-ID"].isNullOrBlank())
     }

--- a/MapboxSearch/sdk/src/main/java/com/mapbox/search/CategorySearchOptions.kt
+++ b/MapboxSearch/sdk/src/main/java/com/mapbox/search/CategorySearchOptions.kt
@@ -132,6 +132,12 @@ public class CategorySearchOptions @JvmOverloads public constructor(
      */
     @Reserved(SEARCH_BOX)
     public val ensureResultsPerCategory: Boolean? = null,
+
+    /**
+     * Request additional metadata attributes besides the basic ones.
+     */
+    @Reserved(SEARCH_BOX)
+    public val attributeSets: List<AttributeSet>? = null,
 ) : Parcelable {
 
     init {
@@ -160,6 +166,7 @@ public class CategorySearchOptions @JvmOverloads public constructor(
         ignoreIndexableRecords: Boolean = this.ignoreIndexableRecords,
         indexableRecordsDistanceThresholdMeters: Double? = this.indexableRecordsDistanceThresholdMeters,
         ensureResultsPerCategory: Boolean? = this.ensureResultsPerCategory,
+        attributeSets: List<AttributeSet>? = this.attributeSets,
     ): CategorySearchOptions {
         return CategorySearchOptions(
             proximity = proximity,
@@ -176,6 +183,7 @@ public class CategorySearchOptions @JvmOverloads public constructor(
             ignoreIndexableRecords = ignoreIndexableRecords,
             indexableRecordsDistanceThresholdMeters = indexableRecordsDistanceThresholdMeters,
             ensureResultsPerCategory = ensureResultsPerCategory,
+            attributeSets = attributeSets,
         )
     }
 
@@ -209,6 +217,7 @@ public class CategorySearchOptions @JvmOverloads public constructor(
         if (ignoreIndexableRecords != other.ignoreIndexableRecords) return false
         if (!indexableRecordsDistanceThresholdMeters.safeCompareTo(other.indexableRecordsDistanceThresholdMeters)) return false
         if (ensureResultsPerCategory != other.ensureResultsPerCategory) return false
+        if (attributeSets != other.attributeSets) return false
 
         return true
     }
@@ -231,6 +240,7 @@ public class CategorySearchOptions @JvmOverloads public constructor(
         result = 31 * result + ignoreIndexableRecords.hashCode()
         result = 31 * result + indexableRecordsDistanceThresholdMeters.hashCode()
         result = 31 * result + ensureResultsPerCategory.hashCode()
+        result = 31 * result + attributeSets.hashCode()
         return result
     }
 
@@ -252,7 +262,8 @@ public class CategorySearchOptions @JvmOverloads public constructor(
                 "unsafeParameters=$unsafeParameters, " +
                 "ignoreIndexableRecords=$ignoreIndexableRecords, " +
                 "indexableRecordsDistanceThresholdMeters=$indexableRecordsDistanceThresholdMeters, " +
-                "ensureResultsPerCategory=$ensureResultsPerCategory" +
+                "ensureResultsPerCategory=$ensureResultsPerCategory, " +
+                "attributeSets=$attributeSets" +
                 ")"
     }
 
@@ -276,6 +287,7 @@ public class CategorySearchOptions @JvmOverloads public constructor(
         private var ignoreIndexableRecords: Boolean = false
         private var indexableRecordsDistanceThresholdMeters: Double? = null
         private var ensureResultsPerCategory: Boolean? = null
+        private var attributeSets: List<AttributeSet>? = null
 
         internal constructor(options: CategorySearchOptions) : this() {
             proximity = options.proximity
@@ -292,6 +304,7 @@ public class CategorySearchOptions @JvmOverloads public constructor(
             ignoreIndexableRecords = options.ignoreIndexableRecords
             indexableRecordsDistanceThresholdMeters = options.indexableRecordsDistanceThresholdMeters
             ensureResultsPerCategory = options.ensureResultsPerCategory
+            attributeSets = options.attributeSets
         }
 
         /**
@@ -428,6 +441,14 @@ public class CategorySearchOptions @JvmOverloads public constructor(
         }
 
         /**
+         * Request additional metadata attributes besides the basic ones.
+         */
+        @Reserved(SEARCH_BOX)
+        public fun attributeSets(attributeSets: List<AttributeSet>?): Builder = apply {
+            this.attributeSets = attributeSets
+        }
+
+        /**
          * Create [CategorySearchOptions] instance from builder data.
          */
         public fun build(): CategorySearchOptions = CategorySearchOptions(
@@ -445,6 +466,7 @@ public class CategorySearchOptions @JvmOverloads public constructor(
             ignoreIndexableRecords = ignoreIndexableRecords,
             indexableRecordsDistanceThresholdMeters = indexableRecordsDistanceThresholdMeters,
             ensureResultsPerCategory = ensureResultsPerCategory,
+            attributeSets = attributeSets,
         )
     }
 }
@@ -467,4 +489,5 @@ internal fun CategorySearchOptions.mapToCoreCategory(): CoreSearchOptions = crea
     timeDeviation = routeOptions?.timeDeviationMinutes,
     addonAPI = unsafeParameters?.let { (it as? HashMap) ?: HashMap(it) },
     ensureResultsPerCategory = ensureResultsPerCategory,
+    attributeSets = attributeSets?.map { it.mapToCore() },
 )

--- a/MapboxSearch/sdk/src/main/java/com/mapbox/search/details/RetrieveDetailsOptions.kt
+++ b/MapboxSearch/sdk/src/main/java/com/mapbox/search/details/RetrieveDetailsOptions.kt
@@ -18,10 +18,7 @@ import kotlinx.parcelize.Parcelize
 public class RetrieveDetailsOptions @JvmOverloads constructor(
 
     /**
-     * Besides the basic metadata attributes, developers can request additional
-     * attributes by setting attribute_sets parameter with attribute set values,
-     * for example &attribute_sets=basic,photos,visit.
-     * The requested metadata will be provided in metadata object in the response.
+     * Request additional metadata attributes besides the basic ones.
      */
     public val attributeSets: List<AttributeSet>? = null,
 
@@ -87,6 +84,7 @@ internal fun RetrieveDetailsOptions.mapToCore(): DetailsOptions {
     )
 }
 
+@JvmSynthetic
 private fun List<AttributeSet>.fixedAttributesOption(): List<AttributeSet> {
     return if (isNotEmpty() && !contains(AttributeSet.BASIC)) {
         this + AttributeSet.BASIC

--- a/MapboxSearch/sdk/src/test/java/com/mapbox/search/CategorySearchOptionsTest.kt
+++ b/MapboxSearch/sdk/src/test/java/com/mapbox/search/CategorySearchOptionsTest.kt
@@ -2,6 +2,7 @@ package com.mapbox.search
 
 import com.mapbox.geojson.BoundingBox
 import com.mapbox.geojson.Point
+import com.mapbox.search.base.core.CoreAttributeSet
 import com.mapbox.search.base.utils.extension.mapToCore
 import com.mapbox.search.common.IsoCountryCode
 import com.mapbox.search.common.IsoLanguageCode
@@ -50,6 +51,7 @@ internal class CategorySearchOptionsTest {
                     ignoreIndexableRecords = false,
                     indexableRecordsDistanceThresholdMeters = null,
                     ensureResultsPerCategory = null,
+                    attributeSets = null,
                 )
 
                 Then("Options should be equal", expectedOptions, actualOptions)
@@ -77,6 +79,7 @@ internal class CategorySearchOptionsTest {
                     .ignoreIndexableRecords(true)
                     .indexableRecordsDistanceThresholdMeters(50.0)
                     .ensureResultsPerCategory(true)
+                    .attributeSets(AttributeSet.values().toList())
                     .build()
 
                 val expectedOptions = CategorySearchOptions(
@@ -94,6 +97,7 @@ internal class CategorySearchOptionsTest {
                     ignoreIndexableRecords = true,
                     indexableRecordsDistanceThresholdMeters = 50.0,
                     ensureResultsPerCategory = true,
+                    attributeSets = AttributeSet.values().toList(),
                 )
 
                 Then("Options should be equal", expectedOptions, actualOptions)
@@ -121,6 +125,7 @@ internal class CategorySearchOptionsTest {
                     .ignoreIndexableRecords(true)
                     .indexableRecordsDistanceThresholdMeters(100.123)
                     .ensureResultsPerCategory(true)
+                    .attributeSets(AttributeSet.values().toList())
                     .build()
 
                 val expectedOptions = CategorySearchOptions(
@@ -138,6 +143,7 @@ internal class CategorySearchOptionsTest {
                     ignoreIndexableRecords = true,
                     indexableRecordsDistanceThresholdMeters = 100.123,
                     ensureResultsPerCategory = true,
+                    attributeSets = AttributeSet.values().toList(),
                 )
 
                 Then("Options should be equal", expectedOptions, actualOptions)
@@ -180,6 +186,14 @@ internal class CategorySearchOptionsTest {
                     .ignoreIndexableRecords(true)
                     .indexableRecordsDistanceThresholdMeters(10.0)
                     .ensureResultsPerCategory(true)
+                    .attributeSets(
+                        listOf(
+                            AttributeSet.BASIC,
+                            AttributeSet.PHOTOS,
+                            AttributeSet.VISIT,
+                            AttributeSet.VENUE,
+                        )
+                    )
                     .build()
 
                 val actualOptions = originalOptions.mapToCoreCategory()
@@ -203,6 +217,12 @@ internal class CategorySearchOptionsTest {
                     timeDeviation = TEST_ROUTE_OPTIONS.timeDeviationMinutes,
                     addonAPI = HashMap(TEST_UNSAFE_PARAMETERS),
                     ensureResultsPerCategory = true,
+                    attributeSets = listOf(
+                        CoreAttributeSet.BASIC,
+                        CoreAttributeSet.PHOTOS,
+                        CoreAttributeSet.VISIT,
+                        CoreAttributeSet.VENUE,
+                    ),
                 )
 
                 Then("Options should be equal", expectedOptions, actualOptions)
@@ -229,6 +249,7 @@ internal class CategorySearchOptionsTest {
                     ignoreIndexableRecords = true,
                     indexableRecordsDistanceThresholdMeters = 15.0,
                     ensureResultsPerCategory = true,
+                    attributeSets = AttributeSet.values().toList(),
                 )
 
                 Then("Options should be equal", options, options.toBuilder().build())


### PR DESCRIPTION
### Description
This PR
- Bumps dependencies versions
- Adds Attributes set support for the category search
- Bumps SDK version name to 2.7

### Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR (where applicable)
- [ ] I have run tests and automatic checks locally
- [ ] I have run `pitest` check locally and checked that the coverage increased (or didn't change) or decreased insignificantly
- [ ] I have made corresponding changes to the documentation (where applicable)
- [ ] I have grouped commits logically or I promise to squash my commits before merge
