### PR TITLE
Update mapbox-sdk to 15.0-SNAPSHOT-08-04--04-42.git-0cacf06.

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -179,6 +179,11 @@ License: [Chromium and built-in dependencies](https://storage.cloud.google.com/c
 
 ===========================================================================
 
+Mapbox Search Android uses portions of the error-prone annotations.  
+License: [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+===========================================================================
+
 Mapbox Search Android uses portions of the Experimental annotation.  
 URL: [https://developer.android.com/jetpack/androidx/releases/annotation#1.3.0](https://developer.android.com/jetpack/androidx/releases/annotation#1.3.0)  
 License: [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
@@ -186,7 +191,7 @@ License: [The Apache Software License, Version 2.0](http://www.apache.org/licens
 ===========================================================================
 
 Mapbox Search Android uses portions of the Gson.  
-License: [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+License: [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
 
 ===========================================================================
 
@@ -493,6 +498,11 @@ License: [Chromium and built-in dependencies](https://storage.cloud.google.com/c
 
 ===========================================================================
 
+Mapbox Search Android uses portions of the error-prone annotations.  
+License: [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+===========================================================================
+
 Mapbox Search Android uses portions of the Experimental annotation.  
 URL: [https://developer.android.com/jetpack/androidx/releases/annotation#1.3.0](https://developer.android.com/jetpack/androidx/releases/annotation#1.3.0)  
 License: [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
@@ -500,7 +510,7 @@ License: [The Apache Software License, Version 2.0](http://www.apache.org/licens
 ===========================================================================
 
 Mapbox Search Android uses portions of the Gson.  
-License: [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+License: [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
 
 ===========================================================================
 
@@ -819,6 +829,11 @@ License: [Chromium and built-in dependencies](https://storage.cloud.google.com/c
 
 ===========================================================================
 
+Mapbox Search Android uses portions of the error-prone annotations.  
+License: [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+===========================================================================
+
 Mapbox Search Android uses portions of the Experimental annotation.  
 URL: [https://developer.android.com/jetpack/androidx/releases/annotation#1.3.0](https://developer.android.com/jetpack/androidx/releases/annotation#1.3.0)  
 License: [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
@@ -826,7 +841,7 @@ License: [The Apache Software License, Version 2.0](http://www.apache.org/licens
 ===========================================================================
 
 Mapbox Search Android uses portions of the Gson.  
-License: [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+License: [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
 
 ===========================================================================
 
@@ -1241,6 +1256,11 @@ License: [Chromium and built-in dependencies](https://storage.cloud.google.com/c
 
 ===========================================================================
 
+Mapbox Search Android uses portions of the error-prone annotations.  
+License: [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+===========================================================================
+
 Mapbox Search Android uses portions of the Experimental annotation.  
 URL: [https://developer.android.com/jetpack/androidx/releases/annotation#1.3.0](https://developer.android.com/jetpack/androidx/releases/annotation#1.3.0)  
 License: [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
@@ -1579,6 +1599,11 @@ License: [Chromium and built-in dependencies](https://storage.cloud.google.com/c
 
 ===========================================================================
 
+Mapbox Search Android uses portions of the error-prone annotations.  
+License: [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+===========================================================================
+
 Mapbox Search Android uses portions of the Experimental annotation.  
 URL: [https://developer.android.com/jetpack/androidx/releases/annotation#1.3.0](https://developer.android.com/jetpack/androidx/releases/annotation#1.3.0)  
 License: [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
@@ -1911,6 +1936,11 @@ License: [Chromium and built-in dependencies](https://storage.cloud.google.com/c
 
 ===========================================================================
 
+Mapbox Search Android uses portions of the error-prone annotations.  
+License: [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+===========================================================================
+
 Mapbox Search Android uses portions of the Experimental annotation.  
 URL: [https://developer.android.com/jetpack/androidx/releases/annotation#1.3.0](https://developer.android.com/jetpack/androidx/releases/annotation#1.3.0)  
 License: [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
@@ -1918,7 +1948,7 @@ License: [The Apache Software License, Version 2.0](http://www.apache.org/licens
 ===========================================================================
 
 Mapbox Search Android uses portions of the Gson.  
-License: [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+License: [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
 
 ===========================================================================
 
@@ -2243,6 +2273,11 @@ License: [Chromium and built-in dependencies](https://storage.cloud.google.com/c
 
 ===========================================================================
 
+Mapbox Search Android uses portions of the error-prone annotations.  
+License: [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+===========================================================================
+
 Mapbox Search Android uses portions of the Experimental annotation.  
 URL: [https://developer.android.com/jetpack/androidx/releases/annotation#1.3.0](https://developer.android.com/jetpack/androidx/releases/annotation#1.3.0)  
 License: [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
@@ -2250,7 +2285,7 @@ License: [The Apache Software License, Version 2.0](http://www.apache.org/licens
 ===========================================================================
 
 Mapbox Search Android uses portions of the Gson.  
-License: [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+License: [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
 
 ===========================================================================
 
@@ -2575,6 +2610,11 @@ License: [Chromium and built-in dependencies](https://storage.cloud.google.com/c
 
 ===========================================================================
 
+Mapbox Search Android uses portions of the error-prone annotations.  
+License: [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+===========================================================================
+
 Mapbox Search Android uses portions of the Experimental annotation.  
 URL: [https://developer.android.com/jetpack/androidx/releases/annotation#1.3.0](https://developer.android.com/jetpack/androidx/releases/annotation#1.3.0)  
 License: [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
@@ -2582,7 +2622,7 @@ License: [The Apache Software License, Version 2.0](http://www.apache.org/licens
 ===========================================================================
 
 Mapbox Search Android uses portions of the Gson.  
-License: [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+License: [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
 
 ===========================================================================
 

--- a/MapboxSearch/gradle.properties
+++ b/MapboxSearch/gradle.properties
@@ -21,7 +21,7 @@ android.enableJetifier=false
 kotlin.code.style=official
 
 # SDK version attributes
-VERSION_NAME=2.14.0
+VERSION_NAME=2.15.0-0cacf06-SNAPSHOT
 
 # Artifact attributes
 mapboxArtifactUserOrg=mapbox

--- a/MapboxSearch/gradle/versions.gradle
+++ b/MapboxSearch/gradle/versions.gradle
@@ -44,9 +44,9 @@ ext {
 
     version = [
             // Mapbox
-            mapboxSearchNative      : '2.14.0',
-            mapboxCommon            : '24.14.0',
-            mapboxMaps              : '11.14.0',
+            mapboxSearchNative      : '2.15.0-SNAPSHOT-08-04--04-42.git-0cacf06',
+            mapboxCommon            : '24.15.0-SNAPSHOT-08-04--04-42.git-0cacf06',
+            mapboxMaps              : '11.15.0-SNAPSHOT-08-04--04-42.git-0cacf06',
             mapboxTurf              : '6.15.0',
             mapboxBase              : '0.8.0',
             mapboxTestDsl           : '0.1.5',

--- a/MapboxSearch/settings.gradle
+++ b/MapboxSearch/settings.gradle
@@ -2,6 +2,24 @@ pluginManagement {
     repositories {
         gradlePluginPortal()
     }
+
+    // see https://issuetracker.google.com/issues/342522142#comment8
+    // needed to workaround AGP 7.4.2 incompatibility with error_prone_annotations:2.38.0
+    // +--- com.mapbox.mapboxsdk:mapbox-sdk-geojson:7.5.0
+    // |    \--- com.google.code.gson:gson:2.13.1
+    // |         \--- com.google.errorprone:error_prone_annotations:2.38.0
+    // TODO update to AGP 8.10.1 used in monorepo for the proper workaround
+    buildscript {
+        repositories {
+            mavenCentral()
+            maven {
+                url = uri("https://storage.googleapis.com/r8-releases/raw")
+            }
+        }
+        dependencies {
+            classpath("com.android.tools:r8:8.1.44")
+        }
+    }
 }
 
 include ':custom-detekt-rules'


### PR DESCRIPTION
<!-- ⚠️ TEMPLATE ⚠️ -->
<!-- Template for GitHub PR descriptions. Use it as a guide on how to describe your work. Feel free to remove any section when you're opening a PR if you think it does not apply for your committed changes. -->

### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->

Update mapbox-sdk to 15.0-SNAPSHOT-08-04--04-42.git-0cacf06. Bump pulls the fresh version of mapbox geojson and transitively com.google.errorprone:error_prone_annotations:2.38.0 which breaks the build. 
Added a workaround to use older version of D8, proper fix requires newer Android Gradle Plugin ticketed here https://mapbox.atlassian.net/browse/NAVAND-6008.


### Screenshots or Gifs
<!-- 
Include media files to provide additional context. It's REALLY useful for UI related PRs (e.g. ![screenshot gif](link))

Please note that you can change image width/height with one of the following ways:
- For specifying size in percentage:
<img src="https://user-images.githubusercontent.com/4005589/120349671-f86c4f80-c306-11eb-8c71-b903666c2bc.png" width=50% height=50%>
- For specifying size in pixels:
<img src="https://user-images.githubusercontent.com/4005589/120349671-f86c4f80-c306-11eb-8c71-b903666c2bc.png" width="200" height="200">
-->


### Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR (where applicable)
- [ ] I have run tests and automatic checks locally
- [ ] I have run `pitest` check locally and checked that the coverage increased (or didn't change) or decreased insignificantly
- [ ] I have made corresponding changes to the documentation (where applicable)
- [ ] I have grouped commits logically or I promise to squash my commits before merge
